### PR TITLE
[WIP] Handle too large disks properly (#991090)

### DIFF
--- a/src/NCPkgPopupDiskspace.h
+++ b/src/NCPkgPopupDiskspace.h
@@ -204,6 +204,7 @@ private:
     NCPkgPopupDiskspace *popupWin;
     ZyppDuSet testDiskUsage;
 
+    // FIXME: not used anymore, might overflow
     std::string usedPercent( FSize used, FSize total );
 
     /**


### PR DESCRIPTION
- Fix for https://bugzilla.suse.com/show_bug.cgi?id=991090
- Very big disks (>8EiB, 2<sup>63</sup>) caused data overflow, the size was interpreted as a negative number
- Still WIP

## Changes

- The libzypp uses (signed) `long long` type, but the sizes are in KiB which means it cannot overflow even with 16EiB partitions.
- So whenever possible directly use the sizes in KiB, do not convert to bytes which might overflow `long long`.


## Screenshots

The original code displayed a warning just after opening the package manager:

![ncurses-pkg-8eib-original-error](https://user-images.githubusercontent.com/907998/42169903-59793d22-7e15-11e8-9e2a-3b01b60e231b.png)

The error is misleading as the big disk is empty, there is no out of space problem. Also notice the negative sizes in the table.

### Fixed Version

There is no error displayed at the startup:

![ncurses-pkg-8eib-fixed-no-error](https://user-images.githubusercontent.com/907998/42170116-e8462c2c-7e15-11e8-844b-b2522ff5e979.png)

And the table contains a correct (positive) disk size:

![ncurses-pkg-8eib-fixed-free-space](https://user-images.githubusercontent.com/907998/42170142-fa94562e-7e15-11e8-89b5-c3064b2e0708.png)

The column alignment is a bit broken because of that big value, the `FSize` class supports only TiB as the biggest unit for formatting numbers.

## Testing

You can fake such a big file system locally by using sparse files mounted via loop back.

```console
# # create two big (6EiB) sparse files
# # do not worry these will take just few bytes in real
# truncate -s 6E /tmp/huge_file1
# truncate -s 6E /tmp/huge_file2

# # create block devices via loopback
# losetup -f /tmp/huge_file1
# losetup -f /tmp/huge_file2

# # get the loopback names, the devices might be different
# # if you already have some loop devices used in the system
# # adapt the devices in the following commands accordingly
# losetup -a
/dev/loop1: [0056]:1171324 (/tmp/huge_file2)
/dev/loop0: [0056]:1171323 (/tmp/huge_file1)

# # create a btrfs over both "disks"
# mkfs.btrfs -K /dev/loop0 /dev/loop1

# # mount it on /mnt2 (/mnt is filtered out by libzypp!)
# mkdir /mnt2
# mount /dev/loop0 /mnt2

# # verify the size
# df -h /mnt2
Filesystem      Size  Used Avail Use% Mounted on
/dev/loop0       12E   17M   12E   1% /mnt2

# # voila! we have 12EiB filesystem! :-)
```