### PR TITLE
Bump the .so version to 10 (bsc#1132247)

### DIFF
--- a/VERSION.cmake
+++ b/VERSION.cmake
@@ -1,11 +1,11 @@
 SET( VERSION_MAJOR "2" )
-SET( VERSION_MINOR "48" )
-SET( VERSION_PATCH "9" )
+SET( VERSION_MINOR "49" )
+SET( VERSION_PATCH "0" )
 SET( VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}" )
 
 ##### This is need for the libyui core, ONLY.
 ##### These will be overridden from exports in LibyuiConfig.cmake
-SET( SONAME_MAJOR "4" )
+SET( SONAME_MAJOR "0" )
 SET( SONAME_MINOR "0" )
 SET( SONAME_PATCH "0" )
 SET( SONAME "${SONAME_MAJOR}.${SONAME_MINOR}.${SONAME_PATCH}" )

--- a/package/libyui-ncurses-pkg-doc.spec
+++ b/package/libyui-ncurses-pkg-doc.spec
@@ -16,10 +16,10 @@
 #
 
 %define parent libyui-ncurses-pkg
-%define so_version 9
+%define so_version 10
 
 Name:           %{parent}-doc
-Version:        2.48.9
+Version:        2.49.0
 Release:        0
 Source:         %{parent}-%{version}.tar.bz2
 

--- a/package/libyui-ncurses-pkg.changes
+++ b/package/libyui-ncurses-pkg.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Apr 11 14:03:53 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Bump the .so version to 10 to be compatible with the other
+  libyui packages (bsc#1132247)
+- 2.49.0
+
+-------------------------------------------------------------------
 Wed Oct 24 12:58:23 WEST 2018 - igonzalezsosa@suse.com
 
 - Remove the RPM Groups view (FATE#326485).

--- a/package/libyui-ncurses-pkg.spec
+++ b/package/libyui-ncurses-pkg.spec
@@ -17,11 +17,11 @@
 
 
 Name:           libyui-ncurses-pkg
-Version:        2.48.9
+Version:        2.49.0
 Release:        0
 Source:         %{name}-%{version}.tar.bz2
 
-%define so_version 9
+%define so_version 10
 %define bin_name %{name}%{so_version}
 
 %if 0%{?suse_version} > 1325


### PR DESCRIPTION
- to be compatible with the other libyui packages
- 2.49.0
- related to https://bugzilla.suse.com/show_bug.cgi?id=1132247 and https://trello.com/c/dtXPHr8H
- Travis fails as it depends on the new libyui base, it builds fine in https://build.opensuse.org/project/monitor/home:lslezak:libyui-rest-api
- Use "0" `SONAME_MAJOR` (it is overridden anyway so use some meaningless number just as a placeholder)