### PR TITLE
Increase SO version for to 11 (fix for #30)

### DIFF
--- a/package/libyui-ncurses-pkg-doc.changes
+++ b/package/libyui-ncurses-pkg-doc.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Dec 11 09:44:57 UTC 2019 - Rodion Iafarov <riafarov@suse.com>
+
+- Increase SO version to 11 (bsc#1132247)
+- 2.50.0
+
+-------------------------------------------------------------------
 Thu Jun 12 14:45:00 CEST 2012 - bjoern.esser@gmail.com
 
 - initial package

--- a/package/libyui-ncurses-pkg-doc.spec
+++ b/package/libyui-ncurses-pkg-doc.spec
@@ -16,7 +16,7 @@
 #
 
 %define parent libyui-ncurses-pkg
-%define so_version 10
+%define so_version 11
 
 Name:           %{parent}-doc
 Version:        2.50.0

--- a/package/libyui-ncurses-pkg.spec
+++ b/package/libyui-ncurses-pkg.spec
@@ -21,7 +21,7 @@ Version:        2.50.0
 Release:        0
 Source:         %{name}-%{version}.tar.bz2
 
-%define so_version 10
+%define so_version 11
 %define bin_name %{name}%{so_version}
 
 %if 0%{?suse_version} > 1325


### PR DESCRIPTION
Missed bumping SO version in both .spec files in #30. Fixing it here.

See https://github.com/libyui/libyui-rest-api/pull/3