### PR TITLE
Handle Retracted Packages (NCurses part)

### DIFF
--- a/package/libyui-ncurses-pkg.spec
+++ b/package/libyui-ncurses-pkg.spec
@@ -64,6 +64,9 @@ Obsoletes:      %(echo `seq -s " " -f "libyui-ncurses-pkg%.f" $(expr %{so_versio
 Provides:       libyui_pkg
 Supplements:    packageand(libyui-ncurses:yast2-packager)
 
+# Selectable::hasRetracted()
+Requires:       libzypp >= 17.21.0
+
 Url:            http://github.com/libyui/
 Summary:        Libyui - yast2 package selector widget for the ncurses UI
 Group:          System/Libraries

--- a/package/libyui-ncurses-pkg.spec
+++ b/package/libyui-ncurses-pkg.spec
@@ -36,7 +36,7 @@ BuildRequires:  pkg-config
 
 %define libyui_ncurses_devel_version    libyui-ncurses-devel >= 2.54.0
 BuildRequires:  %{libyui_ncurses_devel_version}
-%define libzypp_devel_version           libzypp-devel >= 15.11.0
+%define libzypp_devel_version           libzypp-devel >= 17.21.0
 BuildRequires:  %{libzypp_devel_version}
 
 Url:            http://github.com/libyui/

--- a/src/NCPackageSelector.cc
+++ b/src/NCPackageSelector.cc
@@ -137,7 +137,6 @@ NCPackageSelector::NCPackageSelector( long modeFlags )
       , okButton( 0 )
       , cancelButton( 0 )
       , visibleInfo( 0 )
-
 {
     setFlags( modeFlags );
     readSysconfig();
@@ -161,20 +160,17 @@ NCPackageSelector::~NCPackageSelector()
     // NCPackageSelectorPlugin::runPkgSelection
 }
 
+
 void NCPackageSelector::setFlags( long modeFlags )
 {
-    youMode = ( modeFlags & YPkg_OnlineUpdateMode ) ? true : false ;
-
-    updateMode = ( modeFlags & YPkg_UpdateMode ) ? true : false ;
-
-    repoMgrEnabled = (modeFlags & YPkg_RepoMgr) ? true : false;
-
-    testMode = (modeFlags & YPkg_TestMode ) ? true : false ;
-
-    repoMode = ( modeFlags & YPkg_RepoMode ) ? true : false;
-
-    summaryMode = ( modeFlags & YPkg_SummaryMode ) ? true : false;
+    youMode        = ( modeFlags & YPkg_OnlineUpdateMode ) ? true : false;
+    updateMode     = ( modeFlags & YPkg_UpdateMode       ) ? true : false;
+    repoMgrEnabled = ( modeFlags & YPkg_RepoMgr          ) ? true : false;
+    testMode       = ( modeFlags & YPkg_TestMode         ) ? true : false;
+    repoMode       = ( modeFlags & YPkg_RepoMode         ) ? true : false;
+    summaryMode    = ( modeFlags & YPkg_SummaryMode      ) ? true : false;
 }
+
 
 void NCPackageSelector::readSysconfig()
 {
@@ -193,10 +189,11 @@ void NCPackageSelector::readSysconfig()
     }
 }
 
-void NCPackageSelector::writeSysconfig( )
+
+void NCPackageSelector::writeSysconfig()
 {
 
-    if( !actionAtExit.empty() )
+    if ( !actionAtExit.empty() )
     {
         try
         {
@@ -248,6 +245,7 @@ void NCPackageSelector::writeSysconfig( )
     }
 }
 
+
 bool NCPackageSelector::checkNow( bool *ok )
 {
     bool ret = false;
@@ -257,6 +255,7 @@ bool NCPackageSelector::checkNow( bool *ok )
     YDialog::deleteTopmostDialog();
     return ret;
 }
+
 
 bool NCPackageSelector::systemVerification( bool *ok )
 {
@@ -268,6 +267,7 @@ bool NCPackageSelector::systemVerification( bool *ok )
     return ret;
 }
 
+
 bool NCPackageSelector::doInstallRecommended( bool *ok )
 {
     zypp::getZYpp()->resolver()->setIgnoreAlreadyRecommended( false );
@@ -276,6 +276,7 @@ bool NCPackageSelector::doInstallRecommended( bool *ok )
     bool ret = true;
     return ret;
 }
+
 
 //
 // 'Clean dependencies on remove' option' is NOT saved and cannot be set in /etc/sysconfig/yast2.
@@ -286,12 +287,14 @@ bool NCPackageSelector::isCleanDepsOnRemove()
     return zypp::getZYpp()->resolver()->cleandepsOnRemove();
 }
 
+
 void NCPackageSelector::setCleanDepsOnRemove( bool on )
 {
     zypp::getZYpp()->resolver()->setCleandepsOnRemove( on );
     zypp::getZYpp()->resolver()->resolvePool();
     updatePackageList();
 }
+
 
 //
 // 'Install recommended packages' option can be set and is saved
@@ -320,6 +323,7 @@ bool NCPackageSelector::isInstallRecommended()
     return installRecommended;
 }
 
+
 void NCPackageSelector::setInstallRecommended( bool on )
 {
     installRecommended = on;
@@ -347,7 +351,8 @@ bool NCPackageSelector::isAutoCheck()
     return autoCheck;
 }
 
-bool NCPackageSelector::isVerifySystem( )
+
+bool NCPackageSelector::isVerifySystem()
 {
     std::map <std::string,std::string>::const_iterator it = sysconfig.find( OPTION_VERIFY );
 
@@ -359,7 +364,7 @@ bool NCPackageSelector::isVerifySystem( )
         else if ( it->second == "no")
             verifySystem = false;
         else
-           verifySystem = zypp::getZYpp()->resolver()->systemVerification();
+            verifySystem = zypp::getZYpp()->resolver()->systemVerification();
     }
     else
     {
@@ -370,6 +375,7 @@ bool NCPackageSelector::isVerifySystem( )
     return verifySystem;
 }
 
+
 void NCPackageSelector::setVerifySystem( bool on )
 {
     verifySystem = on;
@@ -378,6 +384,7 @@ void NCPackageSelector::setVerifySystem( bool on )
     zypp::getZYpp()->resolver()->resolvePool();
     updatePackageList();
 }
+
 
 //
 // 'Allow vendor change' option is NOT saved and cannot be set in /etc/sysconfig/yast2.
@@ -391,6 +398,7 @@ bool NCPackageSelector::isAllowVendorChange()
     return change;
 }
 
+
 void NCPackageSelector::setAllowVendorChange( bool on )
 {
     zypp::getZYpp()->resolver()->setAllowVendorChange( on );
@@ -398,10 +406,6 @@ void NCPackageSelector::setAllowVendorChange( bool on )
     updatePackageList();
 }
 
-//////////////////////////////////////////////////////////////////
-//
-// detection whether the user has made any changes
-//
 
 void NCPackageSelector::saveState ()
 {
@@ -416,6 +420,7 @@ void NCPackageSelector::saveState ()
     //p.saveState<zypp::Language> ();
 }
 
+
 void NCPackageSelector::restoreState ()
 {
     ZyppPool p = zyppPool ();
@@ -428,6 +433,7 @@ void NCPackageSelector::restoreState ()
     p.restoreState<zypp::Pattern> ();
     //p.restoreState<zypp::Language> ();
 }
+
 
 bool NCPackageSelector::diffState ()
 {
@@ -451,6 +457,7 @@ bool NCPackageSelector::diffState ()
     log << diff << endl;
     return diff;
 }
+
 
 ///////////////////////////////////////////////////////////////////
 //
@@ -520,6 +527,7 @@ bool NCPackageSelector::handleEvent ( const NCursesEvent&   event )
     return retVal;
 }
 
+
 ///////////////////////////////////////////////////////////////////
 //
 // fillPatchSearchList
@@ -528,11 +536,11 @@ bool NCPackageSelector::handleEvent ( const NCursesEvent&   event )
 //
 bool NCPackageSelector::fillPatchSearchList( const std::string & expr, bool checkName, bool checkSum )
 {
-   NCPkgTable * packageList = PackageList();
+    NCPkgTable * packageList = PackageList();
 
     if ( !packageList )
     {
-      return false;
+        return false;
     }
 
     // clear the patch list
@@ -552,7 +560,7 @@ bool NCPackageSelector::fillPatchSearchList( const std::string & expr, bool chec
     }
 
     for( zypp::PoolQuery::Selectable_iterator it = q.selectableBegin();
-	it != q.selectableEnd(); it++)
+         it != q.selectableEnd(); it++)
     {
 	yuiMilestone() << (*it)->name() << endl;
         ZyppPatch patchPtr = tryCastToZyppPatch( (*it)->theObj() );
@@ -622,20 +630,17 @@ bool NCPackageSelector::fillPatchList( NCPkgMenuFilter::PatchFilter filter )
 	switch ( filter )
 	{
 	    case  NCPkgMenuFilter::F_Needed:
-		{
-		    // show common label "Needed Patches"
-		    packageLabel->setLabel( NCPkgStrings::YOUPatches() );
-		    break;
-		}
+                // show common label "Needed Patches"
+                packageLabel->setLabel( NCPkgStrings::YOUPatches() );
+                break;
+
 	    case NCPkgMenuFilter::F_Unneeded:
-		{
-		    packageLabel->setLabel( NCPkgStrings::InstPatches() );
-		    break;
-		}
+                packageLabel->setLabel( NCPkgStrings::InstPatches() );
+                break;
+
 	    default:
-		{
-		    packageLabel->setLabel( NCPkgStrings::Patches() );
-		}
+                packageLabel->setLabel( NCPkgStrings::Patches() );
+                break;
 	}
     }
 
@@ -648,7 +653,7 @@ bool NCPackageSelector::fillPatchList( NCPkgMenuFilter::PatchFilter filter )
 // fillUpdateList
 //
 //
-bool NCPackageSelector::fillUpdateList( )
+bool NCPackageSelector::fillUpdateList()
 {
     NCPkgTable * packageList = PackageList();
 
@@ -694,6 +699,7 @@ bool NCPackageSelector::fillUpdateList( )
 
     return true;
 }
+
 
 ///////////////////////////////////////////////////////////////////
 //
@@ -761,7 +767,9 @@ bool NCPackageSelector::fillPatchPackages ( NCPkgTable * pkgTable, ZyppObj objPt
     return true;
 }
 
+
 // patches
+
 
 ///////////////////////////////////////////////////////////////////
 //
@@ -842,6 +850,7 @@ bool NCPackageSelector::checkPatch( ZyppPatch 	patchPtr,
     return displayPatch;
 }
 
+
 ///////////////////////////////////////////////////////////////////
 //
 // deleteReplacePoint
@@ -870,6 +879,7 @@ wrect NCPackageSelector::deleteReplacePoint()
     return oldSize;
 }
 
+
 ///////////////////////////////////////////////////////////////////
 //
 // showInformation
@@ -891,6 +901,7 @@ void NCPackageSelector::showInformation()
 	infoText->Redraw();
     }
 }
+
 
 ///////////////////////////////////////////////////////////////////
 //
@@ -951,7 +962,7 @@ void NCPackageSelector::showPatchPackages()
 	// set status strategy - don't set extra strategy, use 'normal' package strategy
 	NCPkgStatusStrategy * strategy = new PackageStatStrategy();
 	patchPkgs->setTableType( NCPkgTable::T_PatchPkgs, strategy );
-	patchPkgs->fillHeader( );
+	patchPkgs->fillHeader();
 	patchPkgs->setSize( oldSize.Sze.W, oldSize.Sze.H );
 
 	fillPatchPackages( patchPkgs, packageList->getDataPointer( packageList->getCurrentItem() ) );
@@ -961,9 +972,10 @@ void NCPackageSelector::showPatchPackages()
     }
 }
 
+
 ///////////////////////////////////////////////////////////////////
 //
-// showPatchPkgsVersions
+// showPatchPkgVersions
 //
 // Creates an NCPkgTable (type T_Availables) which is used to show
 // a list of all versions of all packages belonging to a patch
@@ -998,12 +1010,13 @@ void NCPackageSelector::showPatchPkgVersions()
 void NCPackageSelector::clearInfoArea()
 {
     if ( infoText )
-       infoText->setText("");
+        infoText->setText("");
     if ( versionsList )
-	 versionsList->itemsCleared();
+        versionsList->itemsCleared();
 
     packageLabel->setText(".....................................");
 }
+
 
 void NCPackageSelector::replaceFilter( FilterMode mode)
 {
@@ -1024,41 +1037,41 @@ void NCPackageSelector::replaceFilter( FilterMode mode)
 	searchPopup = 0;
     }
 
-    //replace the description area already here, so the next selected
-    //filter can update it right away (#377857)
+    // replace the description area already here, so the next selected
+    // filter can update it right away (#377857)
     replaceFilterDescr( mode == Search );
 
     switch (mode)
     {
 	case Patterns:
 	{
-	   YTableHeader *hhh = new YTableHeader ();
-	   patternPopup = new NCPkgFilterPattern( replPoint, hhh, this );
-	   patternPopup->setSize( oldSize.Sze.W, oldSize.Sze.H );
-	   patternPopup->Redraw();
-	   patternPopup->showPatternPackages();
-	   patternPopup->setKeyboardFocus();
-	   break;
+            YTableHeader *hhh = new YTableHeader ();
+            patternPopup = new NCPkgFilterPattern( replPoint, hhh, this );
+            patternPopup->setSize( oldSize.Sze.W, oldSize.Sze.H );
+            patternPopup->Redraw();
+            patternPopup->showPatternPackages();
+            patternPopup->setKeyboardFocus();
+            break;
 	}
 	case Languages:
 	{
-	   YTableHeader *hhh = new YTableHeader ();
-	   languagePopup = new NCPkgLocaleTable( replPoint, hhh, this );
-	   languagePopup->setSize( oldSize.Sze.W, oldSize.Sze.H );
-	   languagePopup->Redraw();
-	   languagePopup->showLocalePackages();
-	   languagePopup->setKeyboardFocus();
-	   break;
+            YTableHeader *hhh = new YTableHeader ();
+            languagePopup = new NCPkgLocaleTable( replPoint, hhh, this );
+            languagePopup->setSize( oldSize.Sze.W, oldSize.Sze.H );
+            languagePopup->Redraw();
+            languagePopup->showLocalePackages();
+            languagePopup->setKeyboardFocus();
+            break;
 	}
 	case Repositories:
 	{
-	   YTableHeader *hhh = new YTableHeader ();
-	   repoPopup = new NCPkgRepoTable( replPoint, hhh, this );
-	   repoPopup->setSize( oldSize.Sze.W, oldSize.Sze.H );
-	   repoPopup->Redraw();
-	   repoPopup->showRepoPackages();
-	   repoPopup->setKeyboardFocus();
-	   break;
+            YTableHeader *hhh = new YTableHeader ();
+            repoPopup = new NCPkgRepoTable( replPoint, hhh, this );
+            repoPopup->setSize( oldSize.Sze.W, oldSize.Sze.H );
+            repoPopup->Redraw();
+            repoPopup->showRepoPackages();
+            repoPopup->setKeyboardFocus();
+            break;
         }
 	case Services:
 	{
@@ -1078,6 +1091,7 @@ void NCPackageSelector::replaceFilter( FilterMode mode)
 	    searchPopup->Redraw();
 
             searchField = searchPopup->getSearchField();
+
             if ( searchField )
             {
                 searchField->setKeyboardFocus();
@@ -1105,20 +1119,21 @@ void NCPackageSelector::replaceFilter( FilterMode mode)
 
 	default:
 	    yuiError() << "zatim nic" << endl;
+	    break;
     }
 
-   if (mode == Search)
-   {
-       pkgList->itemsCleared();
-       clearInfoArea();
-   }
-   else
-   {
-       pkgList->setCurrentItem(0);
-       pkgList->showInformation ();
-   }
-
+    if (mode == Search)
+    {
+        pkgList->itemsCleared();
+        clearInfoArea();
+    }
+    else
+    {
+        pkgList->setCurrentItem(0);
+        pkgList->showInformation ();
+    }
 }
+
 
 void NCPackageSelector::replaceFilterDescr( bool b )
 {
@@ -1148,6 +1163,7 @@ void NCPackageSelector::replaceFilterDescr( bool b )
     }
 
 }
+
 
 ///////////////////////////////////////////////////////////////////
 //
@@ -1211,7 +1227,7 @@ bool NCPackageSelector::CancelHandler( const NCursesEvent&  event )
 						   );
 	cancelMsg->setPreferredSize( 45, 8 );
 	cancelMsg->focusCancelButton();
-	NCursesEvent input = cancelMsg->showInfoPopup( );
+	NCursesEvent input = cancelMsg->showInfoPopup();
 
 	YDialog::deleteTopmostDialog();
 
@@ -1229,6 +1245,7 @@ bool NCPackageSelector::CancelHandler( const NCursesEvent&  event )
     // return false, which means stop the event loop (see runPkgSelection)
     return false;
 }
+
 
 ///////////////////////////////////////////////////////////////////
 //
@@ -1295,7 +1312,7 @@ bool NCPackageSelector::OkButtonHandler( const NCursesEvent&  event )
 
 	    spaceMsg->setPreferredSize( 50, 10 );
 	    spaceMsg->focusOkButton();
-	    NCursesEvent input = spaceMsg->showInfoPopup( );
+	    NCursesEvent input = spaceMsg->showInfoPopup();
 
 	    YDialog::deleteTopmostDialog();
 
@@ -1333,6 +1350,7 @@ bool NCPackageSelector::OkButtonHandler( const NCursesEvent&  event )
     }
 }
 
+
 bool NCPackageSelector::showPendingLicenseAgreements()
 {
     bool allConfirmed = true;
@@ -1344,6 +1362,7 @@ bool NCPackageSelector::showPendingLicenseAgreements()
 
     return allConfirmed;
 }
+
 
 bool NCPackageSelector::showPendingLicenseAgreements( ZyppPoolIterator begin, ZyppPoolIterator end )
 {
@@ -1371,7 +1390,7 @@ bool NCPackageSelector::showPendingLicenseAgreements( ZyppPoolIterator begin, Zy
 			yuiMilestone() << "Package/Patch " << sel->name().c_str() <<
 			    "has a license" << endl;
 
-			if( ! sel->hasLicenceConfirmed() )
+			if ( ! sel->hasLicenceConfirmed() )
 			{
 			    allConfirmed = showLicenseAgreement( sel, licenseText ) && allConfirmed;
 			}
@@ -1391,6 +1410,7 @@ bool NCPackageSelector::showPendingLicenseAgreements( ZyppPoolIterator begin, Zy
 
     return allConfirmed;
 }
+
 
 bool NCPackageSelector::showLicenseAgreement( ZyppSel & slbPtr , std::string licenseText )
 {
@@ -1423,7 +1443,9 @@ bool NCPackageSelector::showLicenseAgreement( ZyppSel & slbPtr , std::string lic
 	}
 
 	ok = false;
-    } else {
+    }
+    else
+    {
 	yuiMilestone() << "User confirmed license agreement for " << pkgName << endl;
 	slbPtr->setLicenceConfirmed (true);
 	ok = true;
@@ -1432,13 +1454,14 @@ bool NCPackageSelector::showLicenseAgreement( ZyppSel & slbPtr , std::string lic
     return ok;
 }
 
+
 ///////////////////////////////////////////////////////////////////
 //
 // showDependencies
 //
 // Checks and shows the dependencies
 //
-bool NCPackageSelector::showPackageDependencies ( bool doit )
+bool NCPackageSelector::showPackageDependencies( bool doit )
 {
     bool ok = false;
     bool cancel = false;
@@ -1452,21 +1475,13 @@ bool NCPackageSelector::showPackageDependencies ( bool doit )
     return cancel;
 }
 
-///////////////////////////////////////////////////////////////////
-//
-// showDependencies
-//
-// Checks and shows the dependencies
-//
-void NCPackageSelector::showSelectionDependencies ( )
+
+void NCPackageSelector::showSelectionDependencies()
 {
     showPackageDependencies (true);
 }
 
-///////////////////////////////////////////////////////////////////
-//
-// createLicenseText
-//
+
 bool NCPackageSelector::showLicensePopup( std::string pkgName, std::string license )
 {
     std::string html_text = "";
@@ -1492,7 +1507,7 @@ bool NCPackageSelector::showLicensePopup( std::string pkgName, std::string licen
 
     info->setPreferredSize( (NCurses::cols() * 80)/100, (NCurses::lines()*80)/100);
     info->focusOkButton();
-    confirmed = info->showInfoPopup( ) != NCursesEvent::cancel;
+    confirmed = info->showInfoPopup() != NCursesEvent::cancel;
 
     YDialog::deleteTopmostDialog();
 
@@ -1524,7 +1539,7 @@ void NCPackageSelector::showDiskSpace()
     // check whether required diskspace enters the warning range
     if ( diskspacePopup )
     {
-	diskspacePopup->checkDiskSpaceRange( );
+	diskspacePopup->checkDiskSpaceRange();
 	// show pkg_diff, i.e. total difference of disk space (can be negative in installed system
         // if packages are deleted)
         if ( diskspaceLabel )
@@ -1648,7 +1663,7 @@ void NCPackageSelector::createYouLayout( YWidget * selector )
     YAlignment * left4 = YUI::widgetFactory()->createLeft( hSplit );
     depsMenu = new NCPkgMenuDeps( left4, NCPkgStrings::Deps(), this);
 
-       // add the package table
+    // add the package table
     YTableHeader * tableHeader = new YTableHeader();
 
     pkgList = new NCPkgTable( split, tableHeader );
@@ -1664,7 +1679,7 @@ void NCPackageSelector::createYouLayout( YWidget * selector )
     pkgList->setPackager( this );
 
     // set sort strategy
-    std::vector<std::string> pkgHeader = pkgList->getHeader( );
+    std::vector<std::string> pkgHeader = pkgList->getHeader();
     pkgList->setSortStrategy( new NCPkgTableSort( pkgHeader ) );
 
     // HBox for Filter and Disk Space (both in additional HBoxes )
@@ -1714,7 +1729,7 @@ void NCPackageSelector::createYouLayout( YWidget * selector )
 //
 void NCPackageSelector::createPkgLayout( YWidget * selector, NCPkgTable::NCPkgTableType type )
 {
-     // the vertical split is the (only) child of the dialog
+    // the vertical split is the (only) child of the dialog
     YLayoutBox * vsplit = YUI::widgetFactory()->createVBox( selector );
     YLayoutBox * menu_bar = YUI::widgetFactory()->createHBox( vsplit );
     YLayoutBox * panels = YUI::widgetFactory()->createVBox( vsplit );
@@ -1784,7 +1799,7 @@ void NCPackageSelector::createPkgLayout( YWidget * selector, NCPkgTable::NCPkgTa
     pkgList->fillHeader();
 
     // set sort strategy
-    std::vector<std::string> pkgHeader = pkgList->getHeader( );
+    std::vector<std::string> pkgHeader = pkgList->getHeader();
     pkgList->setSortStrategy( new NCPkgTableSort( pkgHeader ) );
 
     // label text + actions menu
@@ -1830,7 +1845,7 @@ void NCPackageSelector::createPkgLayout( YWidget * selector, NCPkgTable::NCPkgTa
 //
 // Fill package list with packages of default RPM group/update list or installable patches
 //
-bool NCPackageSelector::fillDefaultList( )
+bool NCPackageSelector::fillDefaultList()
 {
     if ( !pkgList )
 	return false;
@@ -1861,10 +1876,10 @@ bool NCPackageSelector::fillDefaultList( )
 	    }
 	}
 	case NCPkgTable::T_Packages: {
-		//Search view is the default (#404694)
-		pkgList->setVisibleInfo(NCPkgTable::I_Technical);
-		searchField->setKeyboardFocus();
-	        break;
+            //Search view is the default (#404694)
+            pkgList->setVisibleInfo(NCPkgTable::I_Technical);
+            searchField->setKeyboardFocus();
+            break;
 	}
 	default:
 	    break;
@@ -1885,5 +1900,4 @@ bool NCPackageSelector::fillDefaultList( )
     }
 
     return true;
-
 }

--- a/src/NCPackageSelector.cc
+++ b/src/NCPackageSelector.cc
@@ -141,7 +141,7 @@ NCPackageSelector::NCPackageSelector( long modeFlags )
 {
     setFlags( modeFlags );
     readSysconfig();
-    saveState ();
+    saveState();
     diskspacePopup = new NCPkgDiskspace( testMode );
 
     setInstallRecommended( isInstallRecommended() );
@@ -176,7 +176,7 @@ void NCPackageSelector::setFlags( long modeFlags )
 void NCPackageSelector::readSysconfig()
 {
     sysconfig = zypp::base::sysconfig::read( PATH_TO_YAST_SYSCONFIG );
-    std::map <std::string,std::string>::const_iterator it = sysconfig.find( OPTION_EXIT );
+    std::map <std::string, std::string>::const_iterator it = sysconfig.find( OPTION_EXIT );
 
     if (it != sysconfig.end())
     {
@@ -303,7 +303,7 @@ void NCPackageSelector::setCleanDepsOnRemove( bool on )
 //
 bool NCPackageSelector::isInstallRecommended()
 {
-    std::map <std::string,std::string>::const_iterator it = sysconfig.find( OPTION_RECOMMENDED );
+    std::map <std::string, std::string>::const_iterator it = sysconfig.find( OPTION_RECOMMENDED );
 
     if ( it != sysconfig.end() )
     {
@@ -339,7 +339,7 @@ bool NCPackageSelector::isAutoCheck()
 {
     // automatic dependency check is on by default (check on every click)
 
-    std::map <std::string,std::string>::const_iterator it = sysconfig.find( OPTION_AUTO_CHECK);
+    std::map <std::string, std::string>::const_iterator it = sysconfig.find( OPTION_AUTO_CHECK);
 
     if ( it != sysconfig.end() )
     {
@@ -355,7 +355,7 @@ bool NCPackageSelector::isAutoCheck()
 
 bool NCPackageSelector::isVerifySystem()
 {
-    std::map <std::string,std::string>::const_iterator it = sysconfig.find( OPTION_VERIFY );
+    std::map <std::string, std::string>::const_iterator it = sysconfig.find( OPTION_VERIFY );
 
     if ( it != sysconfig.end() )
     {
@@ -408,53 +408,53 @@ void NCPackageSelector::setAllowVendorChange( bool on )
 }
 
 
-void NCPackageSelector::saveState ()
+void NCPackageSelector::saveState()
 {
-    ZyppPool p = zyppPool ();
+    ZyppPool p = zyppPool();
 
-    p.saveState<zypp::Package> ();
-    p.saveState<zypp::SrcPackage> ();
+    p.saveState<zypp::Package>();
+    p.saveState<zypp::SrcPackage>();
 
-    p.saveState<zypp::Patch> ();
+    p.saveState<zypp::Patch>();
 
-    p.saveState<zypp::Pattern> ();
-    //p.saveState<zypp::Language> ();
+    p.saveState<zypp::Pattern>();
+    // p.saveState<zypp::Language>();
 }
 
 
-void NCPackageSelector::restoreState ()
+void NCPackageSelector::restoreState()
 {
-    ZyppPool p = zyppPool ();
+    ZyppPool p = zyppPool();
 
-    p.restoreState<zypp::Package> ();
-    p.restoreState<zypp::SrcPackage> ();
+    p.restoreState<zypp::Package>();
+    p.restoreState<zypp::SrcPackage>();
 
-    p.restoreState<zypp::Patch> ();
+    p.restoreState<zypp::Patch>();
 
-    p.restoreState<zypp::Pattern> ();
-    //p.restoreState<zypp::Language> ();
+    p.restoreState<zypp::Pattern>();
+    // p.restoreState<zypp::Language>();
 }
 
 
-bool NCPackageSelector::diffState ()
+bool NCPackageSelector::diffState()
 {
-    ZyppPool p = zyppPool ();
+    ZyppPool p = zyppPool();
 
     bool diff = false;
 
     std::ostream & log = yuiMilestone();
     log << "diffState" << endl;
-    diff = diff || p.diffState<zypp::Package> ();
+    diff = diff || p.diffState<zypp::Package>();
     log << diff << endl;
-    diff = diff || p.diffState<zypp::SrcPackage> ();
-    log << diff << endl;
-
-    diff = diff || p.diffState<zypp::Patch> ();
+    diff = diff || p.diffState<zypp::SrcPackage>();
     log << diff << endl;
 
-    diff = diff || p.diffState<zypp::Pattern> ();
+    diff = diff || p.diffState<zypp::Patch>();
     log << diff << endl;
-    //diff = diff || p.diffState<zypp::Language> ();
+
+    diff = diff || p.diffState<zypp::Pattern>();
+    log << diff << endl;
+    // diff = diff || p.diffState<zypp::Language>();
     log << diff << endl;
     return diff;
 }
@@ -519,7 +519,7 @@ bool NCPackageSelector::handleEvent ( const NCursesEvent&   event )
 	    retVal = helpMenu->handleEvent( event );
 	else if ( event.widget == filterMenu )
 	    retVal = filterMenu->handleEvent( event );
-	else if ( event.selection->label().substr(0,4) == "pkg:" )
+	else if ( event.selection->label().substr(0, 4) == "pkg:" )
 	    // handle hyper links
 	    retVal = LinkHandler( event.selection->label() );
 
@@ -545,7 +545,7 @@ bool NCPackageSelector::fillPatchSearchList( const std::string & expr, bool chec
     }
 
     // clear the patch list
-    packageList->itemsCleared ();
+    packageList->itemsCleared();
 
     zypp::PoolQuery q;
     q.addString( expr );
@@ -560,7 +560,7 @@ bool NCPackageSelector::fillPatchSearchList( const std::string & expr, bool chec
         q.addAttribute( zypp::sat::SolvAttr::summary );
     }
 
-    for( zypp::PoolQuery::Selectable_iterator it = q.selectableBegin();
+    for ( zypp::PoolQuery::Selectable_iterator it = q.selectableBegin();
          it != q.selectableEnd(); it++)
     {
 	yuiMilestone() << (*it)->name() << endl;
@@ -598,10 +598,10 @@ bool NCPackageSelector::fillPatchList( NCPkgMenuFilter::PatchFilter filter )
     }
 
     // clear list of patches
-    packageList->itemsCleared ();
+    packageList->itemsCleared();
 
     // get the patch list and sort it
-    std::list<ZyppSel> patchList( zyppPatchesBegin (), zyppPatchesEnd () );
+    std::list<ZyppSel> patchList( zyppPatchesBegin(), zyppPatchesEnd() );
     patchList.sort( sortByName );
     std::list<ZyppSel>::iterator listIt = patchList.begin();
 
@@ -665,7 +665,7 @@ bool NCPackageSelector::fillUpdateList()
     }
 
     // clear the package table
-    packageList->itemsCleared ();
+    packageList->itemsCleared();
 
     std::list<zypp::PoolItem> problemList = zypp::getZYpp()->resolver()->problematicUpdateItems();
 
@@ -712,7 +712,7 @@ bool NCPackageSelector::fillPatchPackages ( NCPkgTable * pkgTable, ZyppObj objPt
     if ( !pkgTable || !objPtr )
 	return false;
 
-    pkgTable->itemsCleared ();
+    pkgTable->itemsCleared();
 
     std::set<ZyppSel> patchSelectables;
     ZyppPatch patchPtr  = tryCastToZyppPatch( objPtr );
@@ -723,7 +723,7 @@ bool NCPackageSelector::fillPatchPackages ( NCPkgTable * pkgTable, ZyppObj objPt
     ZyppPatchContents patchContents( patchPtr->contents() );
 
     yuiMilestone() <<  "Filtering for patch: " << patchPtr->name().c_str() << " number of atoms: "
-		   << patchContents.size() << endl ;
+		   << patchContents.size() << endl;
 
     for ( ZyppPatchContentsIterator it = patchContents.selectableBegin();
 	  it != patchContents.selectableEnd();
@@ -1047,7 +1047,7 @@ void NCPackageSelector::replaceFilter( FilterMode mode )
     {
 	case Patterns:
 	{
-            YTableHeader *hhh = new YTableHeader ();
+            YTableHeader *hhh = new YTableHeader();
             patternPopup = new NCPkgFilterPattern( replPoint, hhh, this );
             patternPopup->setSize( oldSize.Sze.W, oldSize.Sze.H );
             patternPopup->Redraw();
@@ -1057,7 +1057,7 @@ void NCPackageSelector::replaceFilter( FilterMode mode )
 	}
 	case Languages:
 	{
-            YTableHeader *hhh = new YTableHeader ();
+            YTableHeader *hhh = new YTableHeader();
             languagePopup = new NCPkgLocaleTable( replPoint, hhh, this );
             languagePopup->setSize( oldSize.Sze.W, oldSize.Sze.H );
             languagePopup->Redraw();
@@ -1067,7 +1067,7 @@ void NCPackageSelector::replaceFilter( FilterMode mode )
 	}
 	case Repositories:
 	{
-            YTableHeader *hhh = new YTableHeader ();
+            YTableHeader *hhh = new YTableHeader();
             repoPopup = new NCPkgRepoTable( replPoint, hhh, this );
             repoPopup->setSize( oldSize.Sze.W, oldSize.Sze.H );
             repoPopup->Redraw();
@@ -1077,7 +1077,7 @@ void NCPackageSelector::replaceFilter( FilterMode mode )
         }
 	case Services:
 	{
-	   YTableHeader *hhh = new YTableHeader ();
+	   YTableHeader *hhh = new YTableHeader();
 	   servicePopup = new NCPkgServiceTable( replPoint, hhh, this );
 	   servicePopup->setSize( oldSize.Sze.W, oldSize.Sze.H );
 	   servicePopup->Redraw();
@@ -1132,7 +1132,7 @@ void NCPackageSelector::replaceFilter( FilterMode mode )
     else
     {
         pkgList->setCurrentItem(0);
-        pkgList->showInformation ();
+        pkgList->showInformation();
     }
 }
 
@@ -1190,7 +1190,7 @@ bool NCPackageSelector::LinkHandler ( std::string link )
 	{
 	    yuiMilestone() << "Package " << pkgName << " found" << endl;
 	    // open popup with package info
-	    NCPkgPopupDescr * popupDescr = new NCPkgPopupDescr( wpos(1,1), this );
+	    NCPkgPopupDescr * popupDescr = new NCPkgPopupDescr( wpos(1, 1), this );
 	    popupDescr->showInfoPopup( pkgPtr, *i );
 
 	    YDialog::deleteTopmostDialog();
@@ -1217,9 +1217,10 @@ bool NCPackageSelector::LinkHandler ( std::string link )
 //
 bool NCPackageSelector::CancelHandler( const NCursesEvent&  event )
 {
-    bool changes = diffState ();
+    bool changes = diffState();
 
-    if (changes) {
+    if (changes)
+    {
 	// show a popup and ask the user
 	NCPopupInfo * cancelMsg = new NCPopupInfo( wpos( (NCurses::lines()-8)/2, (NCurses::cols()-45)/2 ),
 						   NCPkgStrings::NotifyLabel(),
@@ -1233,13 +1234,14 @@ bool NCPackageSelector::CancelHandler( const NCursesEvent&  event )
 
 	YDialog::deleteTopmostDialog();
 
-	if ( input == NCursesEvent::cancel ) {
+	if ( input == NCursesEvent::cancel )
+        {
 	    // don't leave the package installation dialog
 	    return true;
 	}
     }
 
-    restoreState ();
+    restoreState();
 
     yuiMilestone() <<  "Cancel button pressed - leaving package selection" << endl;
     const_cast<NCursesEvent &>(event).result = "cancel";
@@ -1330,7 +1332,7 @@ bool NCPackageSelector::OkButtonHandler( const NCursesEvent&  event )
     {
 	// clear the saved states
 	// could free some memory?
-	// clearSaveState ();
+	// clearSaveState();
 
 	writeSysconfig();
 	const_cast<NCursesEvent &>(event).result = "accept";
@@ -1753,7 +1755,7 @@ void NCPackageSelector::createPkgLayout( YWidget * selector, NCPkgTable::NCPkgTa
     YLayoutBox * hbox_bottom = YUI::widgetFactory()->createHBox( panels );
 
     YLayoutBox * vbox_left = YUI::widgetFactory()->createVBox( hbox_top );
-    vbox_left->setWeight(YD_HORIZ,1);
+    vbox_left->setWeight(YD_HORIZ, 1);
     YFrame * fr = YUI::widgetFactory()->createFrame (vbox_left, "");
     YLayoutBox * vv = YUI::widgetFactory()->createVBox( fr );
     YAlignment *l = YUI::widgetFactory()->createLeft( vv );
@@ -1781,7 +1783,7 @@ void NCPackageSelector::createPkgLayout( YWidget * selector, NCPkgTable::NCPkgTa
     YTableHeader * tableHeader = new YTableHeader();
 
     YLayoutBox * v = YUI::widgetFactory()->createVBox( hbox_top );
-    v->setWeight(YD_HORIZ,2);
+    v->setWeight(YD_HORIZ, 2);
     pkgList = new NCPkgTable( v, tableHeader );
     YUI_CHECK_NEW( pkgList );
 
@@ -1814,24 +1816,24 @@ void NCPackageSelector::createPkgLayout( YWidget * selector, NCPkgTable::NCPkgTa
     new NCSpacing( hSplit2, YD_HORIZ, true, 0.5 );
     actionMenu = new NCPkgMenuAction ( hSplit2, NCPkgStrings::Actions(), this );
 
-    //Search parameters resp. filter description
+    // Search parameters resp. filter description
     replPoint2 = YUI::widgetFactory()->createReplacePoint( hbox_bottom );
     replPoint2->setWeight(YD_HORIZ, 1);
     searchSet = new NCPkgSearchSettings( replPoint2, NCPkgStrings::SearchIn() );
 
-    //Package description resp. package version table
+    // Package description resp. package version table
     YLayoutBox * vSplit = YUI::widgetFactory()->createVBox( hbox_bottom );
     vSplit->setWeight(YD_HORIZ, 2);
     replacePoint = YUI::widgetFactory()->createReplacePoint( vSplit );
     infoText = new NCPkgPackageDetails( replacePoint, " ", this );
     YUI_CHECK_NEW( infoText );
 
-    //Bottom button bar
+    // Bottom button bar
     YAlignment *ll = YUI::widgetFactory()->createLeft( bottom_bar );
     helpMenu = new NCPkgMenuHelp (ll, _( "&Help" ), this);
     YUI_CHECK_NEW( helpMenu );
 
-    //right-alignment for OK-Cancel
+    // right-alignment for OK-Cancel
     YAlignment *right = YUI::widgetFactory()->createRight( bottom_bar );
     YLayoutBox * hSplit = YUI::widgetFactory()->createHBox( right );
 
@@ -1859,29 +1861,32 @@ bool NCPackageSelector::fillDefaultList()
 
     switch ( pkgList->getTableType() )
     {
-	case NCPkgTable::T_Patches: {
+	case NCPkgTable::T_Patches:
+        {
 	    fillPatchList( NCPkgMenuFilter::F_Needed );	// default: needed patches
 
 	    // set the visible info to long description
 	    pkgList->setVisibleInfo(NCPkgTable::I_PatchDescr);
 	    // show the patch description of the current item
-	    pkgList->showInformation ();
+	    pkgList->showInformation();
             pkgList->setKeyboardFocus();
 	    break;
 	}
-	case NCPkgTable::T_Update: {
+	case NCPkgTable::T_Update:
+        {
 	    if ( ! zypp::getZYpp()->resolver()->problematicUpdateItems().empty() )
 	    {
 		fillUpdateList();
 		// set the visible info to technical information
 		pkgList->setVisibleInfo(NCPkgTable::I_Technical);
                 // show the package information of the current item
-		pkgList->showInformation ();
+		pkgList->showInformation();
 		break;
 	    }
 	}
-	case NCPkgTable::T_Packages: {
-            //Search view is the default (#404694)
+	case NCPkgTable::T_Packages:
+        {
+            // Search view is the default (#404694)
             pkgList->setVisibleInfo(NCPkgTable::I_Technical);
             searchField->setKeyboardFocus();
             break;

--- a/src/NCPackageSelector.h
+++ b/src/NCPackageSelector.h
@@ -262,7 +262,7 @@ public:
     YLabel *PatternLabel() { return patternLabel; }
 
     NCPkgPackageDetails *InfoText() { return infoText; }
-    void setInfoText ( NCPkgPackageDetails *itext ) { infoText = itext ;}
+    void setInfoText ( NCPkgPackageDetails *itext ) { infoText = itext;}
 
     NCPkgTable *VersionsList() { return versionsList; }
     void setVersionsList ( NCPkgTable *table ) { versionsList = table; }
@@ -290,7 +290,7 @@ public:
      * Fills the package table with packages with update problems
      * @return bool
      */
-    bool fillUpdateList( );
+    bool fillUpdateList();
 
 
     /**
@@ -433,7 +433,7 @@ public:
     /**
      * Checks and shows the selectiondependencies
      */
-    void showSelectionDependencies ( );
+    void showSelectionDependencies();
 
     /**
      * Updates the status in list of packages

--- a/src/NCPackageSelector.h
+++ b/src/NCPackageSelector.h
@@ -108,17 +108,17 @@ inline bool ic_compare ( char c1, char c2 )
 //
 //	CLASS NAME : NCPackageSelector
 //
-//	DESCRIPTION : holds the data and handles events
+//	DESCRIPTION : Specialized high-level widget for package selection
 //
 class NCPackageSelector
 {
 
-  friend std::ostream & operator<<( std::ostream & STREAM, const NCPackageSelector & OBJ );
+    friend std::ostream & operator<<( std::ostream & STREAM, const NCPackageSelector & OBJ );
 
-  NCPackageSelector & operator=( const NCPackageSelector & );
-  NCPackageSelector            ( const NCPackageSelector & );
+    NCPackageSelector & operator=( const NCPackageSelector & );
+    NCPackageSelector            ( const NCPackageSelector & );
 
-  private:
+private:
 
     // typedef for the pointer to handler member function
     typedef bool (NCPackageSelector::* tHandlerFctPtr) ( const NCursesEvent& event );
@@ -130,7 +130,7 @@ class NCPackageSelector
 
     NCPkgPopupDeps * depsPopup;		// the package dependeny popup
 
-    NCPkgFilterPattern * patternPopup;    	// the pattern popup
+    NCPkgFilterPattern * patternPopup;  // the pattern popup
     NCPkgLocaleTable * languagePopup;	// language popup
     NCPkgRepoTable * repoPopup;
     NCPkgServiceTable * servicePopup;
@@ -173,7 +173,7 @@ class NCPackageSelector
     // FIXME - add update list to NCPkgFilterMain
     YMenuItem * updatelistItem;
 
-     // labels
+    // labels
     YLabel * packageLabel;
     YLabel * diskspaceLabel;
     YLabel *patternLabel;
@@ -183,13 +183,13 @@ class NCPackageSelector
     NCRichText * filter_desc;
     NCInputField *searchField;
     NCPkgSearchSettings *searchSet;
-    YReplacePoint * replacePoint; // replace point for info text
+    YReplacePoint * replacePoint;       // replace point for info text
     YReplacePoint * replPoint;
-    YReplacePoint * replPoint2; //tohle pak urcite prejmenuj, Bublino
+    YReplacePoint * replPoint2;
 
-    NCPkgTable * versionsList;	// list of available package versions
+    NCPkgTable * versionsList;          // list of available package versions
     // information about patches
-    NCPkgTable * patchPkgs;	// pakages belonging to a patch
+    NCPkgTable * patchPkgs;             // pakages belonging to a patch
     NCPkgTable * patchPkgsVersions;	// versions of packages above
 
     NCPushButton * okButton;
@@ -197,24 +197,26 @@ class NCPackageSelector
 
     YMenuItem * visibleInfo;		// current visible package info (description, file list, ...)
 
-    // Mapping from ZyppPkg to the correspoinding ZyppSel.
+    // Mapping from ZyppPkg to the corresponding ZyppSel.
     NCPkgSelMapper selMapper;
 
     std::set<std::string> verified_pkgs;
 
-  public:
-	enum FilterMode
-	{
-	    Patterns,
-	    Languages,
-	    Repositories,
-            Services,
-	    Search,
-	    Summary,
-            PkgClassification
-	};
 
-   /**
+public:
+
+    enum FilterMode
+    {
+        Patterns,
+        Languages,
+        Repositories,
+        Services,
+        Search,
+        Summary,
+        PkgClassification
+    };
+
+    /**
      * The package selector class handles the events and holds the
      * data needed for the package selection.
      * @param ui The NCurses UI
@@ -233,18 +235,18 @@ class NCPackageSelector
     void writeSysconfig();
 
     /**
-    * Create layout for the PackageSelector
-    * @param parent Parent is PackageSelectorStart
-    * @param type   The package table type
-    * @return void
-    */
+     * Create layout for the PackageSelector
+     * @param parent Parent is PackageSelectorStart
+     * @param type   The package table type
+     * @return void
+     */
     void createPkgLayout( YWidget * parent, NCPkgTable::NCPkgTableType type );
 
     /**
-    * Create layout for the Online Update
-    * @param parent Parent is PackageSelectorStart
-    * @return void
-    */
+     * Create layout for the Online Update
+     * @param parent Parent is PackageSelectorStart
+     * @return void
+     */
     void createYouLayout( YWidget * parent );
 
     // returns the package table widget
@@ -273,44 +275,44 @@ class NCPackageSelector
 
 
     /**
-    * Fills the package table with YOU patches matching the filter
-    * @param filter
-    * @return bool
-    */
+     * Fills the package table with YOU patches matching the filter
+     * @param filter
+     * @return bool
+     */
     bool fillPatchList( NCPkgMenuFilter::PatchFilter filter );
 
-   /**
-    * Fills the package table with packages with update problems
-    * @return bool
-    */
+    /**
+     * Fills the package table with packages with update problems
+     * @return bool
+     */
     bool fillUpdateList( );
 
 
-   /**
-    * Fills the list of packages belonging to the youPatch
-    * @param pkgTable  The table widget
-    * @param youPatch Show all packages belonging to the patch
-    * @return bool
-    */
+    /**
+     * Fills the list of packages belonging to the youPatch
+     * @param pkgTable  The table widget
+     * @param youPatch Show all packages belonging to the patch
+     * @return bool
+     */
     bool fillPatchPackages ( NCPkgTable * pkgTable, ZyppObj youPatch );
 
-   /**
-    * Fills the package table with packages matching the search expression
-    * @param expr The search expression
-    * @param ignoreCase Ignore case (true or false)
-    * @param checkName Search in package name (true or false)
-    * @param checkSummary Check the summary (true or false)
-    * @param checkProvides Check in Provides (true or false)
-    * @param checkRequires Check in Requires (true or false)
-    * @return bool
-    */
+    /**
+     * Fills the package table with packages matching the search expression
+     * @param expr The search expression
+     * @param ignoreCase Ignore case (true or false)
+     * @param checkName Search in package name (true or false)
+     * @param checkSummary Check the summary (true or false)
+     * @param checkProvides Check in Provides (true or false)
+     * @param checkRequires Check in Requires (true or false)
+     * @return bool
+     */
     bool fillPatchSearchList( const std::string & expr, bool checkName, bool checkSum );
 
-   /**
-    * Fills the default package table
-    */
+    /**
+     * Fills the default package table
+     */
     bool fillDefaultList();
-    
+
     bool isYouMode() { return youMode; }
 
     bool isUpdateMode() { return updateMode; }
@@ -353,8 +355,8 @@ class NCPackageSelector
     bool isAutoCheck();
     void setAutoCheck( bool check) { autoCheck = check; }
     bool AutoCheck() { return autoCheck; }
-    
-     /**
+
+    /**
      * Handle the given event. For the given event (the widget-id
      * is contained in the event) the corresponding handler is executed.
      * @param event The NCurses event
@@ -363,31 +365,31 @@ class NCPackageSelector
     bool handleEvent( const NCursesEvent& event );
 
     /**
-    * Creates an NCPkgTable widget and shows all versions
-    * of all packages belonging to a patch
-    * @return void
-    */
+     * Creates an NCPkgTable widget and shows all versions
+     * of all packages belonging to a patch
+     * @return void
+     */
     void showPatchPkgVersions();
 
     /**
-    * Creates an NCPkgTable widget and shows all packages
-    * belonging to a patch
-    * @return void
-    */
+     * Creates an NCPkgTable widget and shows all packages
+     * belonging to a patch
+     * @return void
+     */
     void showPatchPackages();
 
     /**
-    * Creates an NCPkgTable widget and shows all verions
-    * a the selected package
-    * @return void
-    */
+     * Creates an NCPkgTable widget and shows all verions
+     * a the selected package
+     * @return void
+     */
     void showVersionsList();
 
     /**
-    * Creates an NCRichText widget for package (patch)
-    * information
-    * @return void
-    */
+     * Creates an NCRichText widget for package (patch)
+     * information
+     * @return void
+     */
     void showInformation();
 
     void clearInfoArea();
@@ -397,20 +399,20 @@ class NCPackageSelector
     void replaceFilter ( FilterMode mode);
     void replaceFilterDescr ( bool b );
     /**
-    * Handler function for "OK button pressed"
-    * @param event The Ncurses event
-    * @return bool
-    */
+     * Handler function for "OK button pressed"
+     * @param event The Ncurses event
+     * @return bool
+     */
     bool OkButtonHandler ( const NCursesEvent& event );
 
-   /**
-    * Handler function for "Cancel button pressed"
-    * @param event The Ncurses event
-    * @return bool
-    */
+    /**
+     * Handler function for "Cancel button pressed"
+     * @param event The Ncurses event
+     * @return bool
+     */
     bool CancelHandler ( const NCursesEvent& event );
 
-   /**
+    /**
      * Handles hyperlinks in package description
      * @param link The link
      * @return bool
@@ -418,22 +420,22 @@ class NCPackageSelector
     bool LinkHandler ( std::string link );
 
     /**
-    * Checks and shows the dependencies
-    * @param doit true: do the check, false: only check if auto check is on
-    */
+     * Checks and shows the dependencies
+     * @param doit true: do the check, false: only check if auto check is on
+     */
     bool showPackageDependencies ( bool doit );
 
     /**
-    * Checks and shows the selectiondependencies
-    */
+     * Checks and shows the selectiondependencies
+     */
     void showSelectionDependencies ( );
 
-   /**
-    * Updates the status in list of packages
-    */
+    /**
+     * Updates the status in list of packages
+     */
     void updatePackageList();
 
-     /**
+    /**
      * Check if 'patch' matches the selected filter.
      * Returns true if there is a match, false otherwise or if 'patch' is 0.
      * @return bool
@@ -467,33 +469,34 @@ class NCPackageSelector
     void restoreState();
     bool diffState();
 
-   /**
+    /**
      * Check for license
      */
     bool showPendingLicenseAgreements();
     bool showPendingLicenseAgreements( ZyppPoolIterator begin, ZyppPoolIterator end );
 
-   /**
-    * Show popup with license.
-    * @return bool
-    */
+    /**
+     * Show popup with license.
+     * @return bool
+     */
     bool showLicenseAgreement( ZyppSel & slbPtr , std::string licenseText );
 
-   /**
-    * Get list of packages already selected for automatic changes
-    * (usually via 'verify system' call)
-    * @return std::set <std::string>
-    */
+    /**
+     * Get list of packages already selected for automatic changes
+     * (usually via 'verify system' call)
+     * @return std::set <std::string>
+     */
     std::set <std::string> getVerifiedPkgs()
     {
-	return verified_pkgs;
+        return verified_pkgs;
     }
 
     /**
      * Insert package name into the list of already selected for automatic changes
      * @param pkgname Package name
      */
-    void insertVerifiedPkg( std::string pkgname ) {
+    void insertVerifiedPkg( std::string pkgname )
+    {
 	verified_pkgs.insert( pkgname);
     }
 
@@ -501,7 +504,8 @@ class NCPackageSelector
      * Empty the std::set of packages selected for automatic changes
      * @return void
      */
-    void clearVerifiedPkgs() {
+    void clearVerifiedPkgs()
+    {
 	if ( !verified_pkgs.empty() )
 	{
 	    yuiMilestone() << "Discarding auto-dependency changes" << std::endl;
@@ -511,6 +515,5 @@ class NCPackageSelector
 
 };
 
-///////////////////////////////////////////////////////////////////
 
 #endif // NCPackageSelector_h

--- a/src/NCPackageSelector.h
+++ b/src/NCPackageSelector.h
@@ -249,6 +249,11 @@ public:
      */
     void createYouLayout( YWidget * parent );
 
+    /**
+     * Return 'true' if any package is installed in a retracted version.
+     **/
+    bool anyRetractedPkgInstalled();
+
     // returns the package table widget
     NCPkgTable * PackageList();
     NCPkgPopupDeps *DepsPopup() { return depsPopup; }

--- a/src/NCPackageSelectorPluginImpl.cc
+++ b/src/NCPackageSelectorPluginImpl.cc
@@ -61,8 +61,9 @@ using std::endl;
 //
 NCPackageSelectorPluginImpl PSP;
 
-YPackageSelector * NCPackageSelectorPluginImpl::createPackageSelector( YWidget * parent,
-								       long modeFlags )
+YPackageSelector *
+NCPackageSelectorPluginImpl::createPackageSelector( YWidget * parent,
+                                                    long      modeFlags )
 {
     YWidget * w = 0;
 
@@ -72,7 +73,7 @@ YPackageSelector * NCPackageSelectorPluginImpl::createPackageSelector( YWidget *
     }
     catch (const std::exception & e)
     {
-	yuiError() << "Caught a std::exception: " << e.what () << endl;
+	yuiError() << "Caught a std::exception: " << e.what() << endl;
     }
     catch (...)
     {
@@ -84,6 +85,7 @@ YPackageSelector * NCPackageSelectorPluginImpl::createPackageSelector( YWidget *
     return (YPackageSelector *)(w);
 }
 
+
 ///////////////////////////////////////////////////////////////////
 //
 //
@@ -93,7 +95,8 @@ YPackageSelector * NCPackageSelectorPluginImpl::createPackageSelector( YWidget *
 //	DESCRIPTION : creates special widgets used for the package selection
 //		      dialog (which do not have a corresponding widget in qt-ui)
 //
-YWidget * NCPackageSelectorPluginImpl::createPkgSpecial( YWidget *parent, const std::string &subwidget )
+YWidget *
+NCPackageSelectorPluginImpl::createPkgSpecial( YWidget *parent, const std::string &subwidget )
 {
     YWidget * w = 0;
     YTableHeader * tableHeader = new YTableHeader();
@@ -103,12 +106,12 @@ YWidget * NCPackageSelectorPluginImpl::createPkgSpecial( YWidget *parent, const 
 	yuiDebug() << "Creating a NCPkgTable" << endl;
 	try
 	{
-	    //yuiError() << "Tady taky nic neni " << endl;
+	    // yuiError() << "Tady taky nic neni " << endl;
 	    w = new NCPkgTable( parent, tableHeader );
 	}
 	catch (const std::exception & e)
 	{
-	    yuiError() << "Caught a std::exception: " << e.what () << endl;
+	    yuiError() << "Caught a std::exception: " << e.what() << endl;
 	}
 	catch (...)
 	{
@@ -124,6 +127,7 @@ YWidget * NCPackageSelectorPluginImpl::createPkgSpecial( YWidget *parent, const 
     return w;
 }
 
+
 ///////////////////////////////////////////////////////////////////
 //
 //
@@ -133,8 +137,9 @@ YWidget * NCPackageSelectorPluginImpl::createPkgSpecial( YWidget *parent, const 
 //	DESCRIPTION : Implementation of UI builtin RunPkgSelection() which
 //		      has to be called after OpenDialog( `PackageSelector() ).
 //
-YEvent * NCPackageSelectorPluginImpl::runPkgSelection(  YDialog * dialog,
-						    YWidget * selector )
+YEvent *
+NCPackageSelectorPluginImpl::runPkgSelection(  YDialog * dialog,
+                                               YWidget * selector )
 {
     NCPackageSelectorStart * ncSelector = 0;
 
@@ -164,7 +169,7 @@ YEvent * NCPackageSelectorPluginImpl::runPkgSelection(  YDialog * dialog,
 	try
 	{
 	    ncSelector->showDefaultList();
-            ncd->setStatusLine();       // show function keys 
+            ncd->setStatusLine();       // show function keys
 	    yuiMilestone() << "NCDialog: " << ncd << endl;
 	    do
 	    {
@@ -178,7 +183,7 @@ YEvent * NCPackageSelectorPluginImpl::runPkgSelection(  YDialog * dialog,
 	}
 	catch (const std::exception & e)
 	{
-	    yuiError() << "Caught a std::exception: " << e.what () << endl;
+	    yuiError() << "Caught a std::exception: " << e.what() << endl;
 	}
 	catch (...)
 	{
@@ -195,9 +200,9 @@ YEvent * NCPackageSelectorPluginImpl::runPkgSelection(  YDialog * dialog,
         // Before returning some value to the YCP client,
 	// we must delete (==close) any leftover dialogs,
 	// Wizard will not do it for us (#354712)
-        while( YDialog::topmostDialog() != dialog ) {
-		YDialog::deleteTopmostDialog();
-	}
+        while( YDialog::topmostDialog() != dialog )
+            YDialog::deleteTopmostDialog();
+
 	yuiMilestone() << "Return value: " << event.result << endl;
 	return new YMenuEvent( event.result );
     }

--- a/src/NCPackageSelectorPluginImpl.h
+++ b/src/NCPackageSelectorPluginImpl.h
@@ -38,14 +38,14 @@
   Author:	Hedgehog Painter <kmachalkova@suse.cz>
 
 
-/-*/ 
+/-*/
 
 #ifndef NCPackageSelectorPluginImpl_h
 #define NCPackageSelectorPluginImpl_h
 
 #include "NCPackageSelectorPluginIf.h"
 
-class NCPackageSelectorPluginImpl : public NCPackageSelectorPluginIf 
+class NCPackageSelectorPluginImpl : public NCPackageSelectorPluginIf
 {
 
   public:

--- a/src/NCPackageSelectorStart.h
+++ b/src/NCPackageSelectorStart.h
@@ -67,15 +67,16 @@ class NCPackageSelectorStart : public NCLayoutBox
   NCPackageSelectorStart            ( const NCPackageSelectorStart & );
 
   private:
-    
+
     NCPackageSelector *packager;	// packager object contains the data and handles events
-    
+
   protected:
 
-    virtual const char * location() const {
-      return primary() == YD_HORIZ ? "NC(H)PackageSelectorStart" : "NC(V)PackageSelectorStart" ;
+    virtual const char * location() const
+    {
+      return primary() == YD_HORIZ ? "NC(H)PackageSelectorStart" : "NC(V)PackageSelectorStart";
     }
-    
+
   public:
 
     /**
@@ -93,7 +94,7 @@ class NCPackageSelectorStart : public NCLayoutBox
 
     virtual int preferredWidth() { return NCLayoutBox::preferredWidth(); }
     virtual int preferredHeight() { return NCLayoutBox::preferredHeight(); }
- 
+
     /**
      * Set the new size of the widget.
      *
@@ -102,7 +103,7 @@ class NCPackageSelectorStart : public NCLayoutBox
     virtual void setSize( int newWidth, int newHeight );
 
     /**
-     * Fills the package table with packages belonging to the  
+     * Fills the package table with packages belonging to the
      * default filter (the filter which is selected when entering the
      * package selection).
      **/
@@ -115,7 +116,7 @@ class NCPackageSelectorStart : public NCLayoutBox
      * @return bool
      */
     bool handleEvent( const NCursesEvent&   event );
-        
+
 };
 
 ///////////////////////////////////////////////////////////////////

--- a/src/NCPkgFilterClassification.cc
+++ b/src/NCPkgFilterClassification.cc
@@ -139,24 +139,24 @@ bool NCPkgFilterClassification::showPackages( )
         // identical candidate available from a repo.
         if ( selectable->installedObj() )
         {
-           match = check( selectable, tryCastToZyppPkg( selectable->installedObj() ), pkgClass );
+            match = check( selectable, tryCastToZyppPkg( selectable->installedObj() ), pkgClass );
         }
         // otherwise display the candidate object (the "best" version)
         else if ( selectable->hasCandidateObj() )
         {
-           match = check( selectable, tryCastToZyppPkg( selectable->candidateObj() ), pkgClass );
+            match = check( selectable, tryCastToZyppPkg( selectable->candidateObj() ), pkgClass );
         }
 
         // And then check the pick list which contain all availables and all objects for multi
         // version packages and the installed obj if there isn't same version in a repo.
         if ( !match )
         {
-          zypp::ui::Selectable::picklist_iterator it = selectable->picklistBegin();
-          while ( it != selectable->picklistEnd() && !match )
-          {
-            check( selectable, tryCastToZyppPkg( *it ), pkgClass );
-            ++it;
-          }
+            zypp::ui::Selectable::picklist_iterator it = selectable->picklistBegin();
+            while ( it != selectable->picklistEnd() && !match )
+            {
+                check( selectable, tryCastToZyppPkg( *it ), pkgClass );
+                ++it;
+            }
         }
     }
 
@@ -272,8 +272,9 @@ NCursesEvent NCPkgFilterClassification::wHandleInput( wint_t ch )
             break;
 
 	default:
-	   ret = NCSelectionBox::wHandleInput( ch ) ;
-     }
+            ret = NCSelectionBox::wHandleInput( ch ) ;
+            break;
+    }
 
     return ret;
 }

--- a/src/NCPkgFilterClassification.cc
+++ b/src/NCPkgFilterClassification.cc
@@ -68,7 +68,7 @@ using std::endl;
 
 NCPkgFilterClassification::NCPkgFilterClassification( YWidget *parent, NCPackageSelector *pkg )
     :NCSelectionBox( parent, "" )
-    ,packager( pkg )
+    , packager( pkg )
 {
     // fill selection box
     suggested = new YItem( _("Suggested Packages") );
@@ -116,7 +116,7 @@ bool NCPkgFilterClassification::showPackages()
     }
 
     // clear the package table
-    packageList->itemsCleared ();
+    packageList->itemsCleared();
 
     for ( ZyppPoolIterator it = zyppPkgBegin();
           it != zyppPkgEnd();
@@ -296,7 +296,7 @@ NCursesEvent NCPkgFilterClassification::wHandleInput( wint_t ch )
             break;
 
 	default:
-            ret = NCSelectionBox::wHandleInput( ch ) ;
+            ret = NCSelectionBox::wHandleInput( ch );
             break;
     }
 

--- a/src/NCPkgFilterClassification.h
+++ b/src/NCPkgFilterClassification.h
@@ -35,7 +35,7 @@
 
    File:       NCPkgFilterClassification.h
 
-   Author:     Gabriele Mohr <gs@suse.com> 
+   Author:     Gabriele Mohr <gs@suse.com>
 
 /-*/
 
@@ -61,10 +61,36 @@ class NCPackageSelector;
 
 class NCPkgFilterClassification: public NCSelectionBox
 {
-private:
+public:
 
-    NCPkgFilterClassification & operator=( const NCPkgFilterClassification & );
-    NCPkgFilterClassification            ( const NCPkgFilterClassification & );
+    /**
+      * A helper class to hold repository data in a neat table
+      * widget
+      * @param parent A parent widget
+      * @param opt Widget options
+      */
+
+    NCPkgFilterClassification( YWidget *parent, NCPackageSelector *pkg);
+
+    virtual ~NCPkgFilterClassification() {};
+
+    void showRetractedInstalled();
+
+    virtual NCursesEvent wHandleInput( wint_t ch );
+
+protected:
+
+    YItem * currentPkgClass() const;
+    void setCurrentPkgClass( YItem * item );
+    int itemIndex( YItem * item ) const;
+    
+    bool showPackages();
+    void showDescription();
+
+    bool check(ZyppSel selectable, ZyppPkg pkg, YItem * group );
+
+
+    // Data members
 
     NCPackageSelector *packager;
 
@@ -77,35 +103,10 @@ private:
     YItem *retractedInstalled;
     YItem *all;
 
-    bool check (ZyppSel selectable, ZyppPkg pkg, YItem * group );
-    
-public:
+private:
 
-    /**
-      * A helper class to hold repository data in a neat table
-      * widget
-      * @param parent A parent widget
-      * @param opt Widget options
-      */
-
-    NCPkgFilterClassification  ( YWidget *parent, NCPackageSelector *pkg);
-
-    virtual ~NCPkgFilterClassification() {};
-
-    /**
-      * Get currently selected package group item
-      */
-    YItem * getCurrentPkgClass();
-
-
-    virtual NCursesEvent wHandleInput ( wint_t ch );
-
-    /**
-     * Fill package list
-     */ 
-    bool showPackages();
-    
-    void showDescription();
+    NCPkgFilterClassification & operator=( const NCPkgFilterClassification & );
+    NCPkgFilterClassification            ( const NCPkgFilterClassification & );
 
 };
 #endif

--- a/src/NCPkgFilterClassification.h
+++ b/src/NCPkgFilterClassification.h
@@ -73,6 +73,8 @@ private:
     YItem *orphaned;
     YItem *unneeded;
     YItem *multiversion;
+    YItem *retracted;
+    YItem *retractedInstalled;
     YItem *all;
 
     bool check (ZyppSel selectable, ZyppPkg pkg, YItem * group );
@@ -93,7 +95,7 @@ public:
     /**
       * Get currently selected package group item
       */
-    YItem * getCurrentGroup();
+    YItem * getCurrentPkgClass();
 
 
     virtual NCursesEvent wHandleInput ( wint_t ch );
@@ -101,9 +103,9 @@ public:
     /**
      * Fill package list
      */ 
-    bool showPackages( );
+    bool showPackages();
     
-    void showDescription( );
+    void showDescription();
 
 };
 #endif

--- a/src/NCPkgFilterClassification.h
+++ b/src/NCPkgFilterClassification.h
@@ -83,7 +83,7 @@ protected:
     YItem * currentPkgClass() const;
     void setCurrentPkgClass( YItem * item );
     int itemIndex( YItem * item ) const;
-    
+
     bool showPackages();
     void showDescription();
 

--- a/src/NCPkgFilterInstSummary.cc
+++ b/src/NCPkgFilterInstSummary.cc
@@ -51,7 +51,7 @@ NCPkgFilterInstSummary::NCPkgFilterInstSummary ( YWidget *parent, std::string la
 	: NCMultiSelectionBox ( parent, label)
 	, pkg( pkger )
 {
-    //setNotify(true);
+    // setNotify(true);
     createLayout();
 }
 
@@ -89,7 +89,7 @@ bool NCPkgFilterInstSummary::check( ZyppObj opkg, ZyppSel slb )
 
     switch ( slb->status() )
     {
-	//group these two together, due to lack of space
+	// group these two together, due to lack of space
 	case S_Del:
 	case S_AutoDel: 	show = del->selected();	break;
 	case S_Install:
@@ -125,7 +125,7 @@ bool NCPkgFilterInstSummary::showInstSummaryPackages()
     }
 
     // clear the package table
-    packageList->itemsCleared ();
+    packageList->itemsCleared();
 
 
     for_( listIt, zyppPkgBegin(), zyppPkgEnd() )
@@ -141,7 +141,7 @@ bool NCPkgFilterInstSummary::showInstSummaryPackages()
 					   : ( obj = selectable->theObj() );
 	}
 
-	if( check( obj, selectable ) )
+	if ( check( obj, selectable ) )
 	{
     	    ZyppPkg pkg = tryCastToZyppPkg (obj);
 	    packageList->createListEntry( pkg, selectable);
@@ -164,15 +164,14 @@ NCursesEvent NCPkgFilterInstSummary::wHandleInput( wint_t ch )
 {
     NCursesEvent ret = NCursesEvent::none;
 
-    //treat this like any other MultiSelBox input ...
-    NCMultiSelectionBox::wHandleInput( ch ) ;
+    // treat this like any other MultiSelBox input ...
+    NCMultiSelectionBox::wHandleInput( ch );
     switch ( ch )
     {
-	//special case for toggling item status
+	// special case for toggling item status
 	case KEY_SPACE:
-	case KEY_RETURN: {
+	case KEY_RETURN:
 	    showInstSummaryPackages();
-	}
     }
 
     //... but do not return to the main loop

--- a/src/NCPkgFilterInstSummary.h
+++ b/src/NCPkgFilterInstSummary.h
@@ -51,8 +51,8 @@
 #include "NCMultiSelectionBox.h"
 #include "NCZypp.h"
 
-class NCPkgFilterInstSummary : public NCMultiSelectionBox {
-
+class NCPkgFilterInstSummary : public NCMultiSelectionBox
+{
     NCPkgFilterInstSummary & operator=( const NCPkgFilterInstSummary & );
     NCPkgFilterInstSummary             ( const NCPkgFilterInstSummary & );
 
@@ -66,13 +66,13 @@ public:
     YItem *inst;
     YItem *update;
     YItem *taboo;
-    YItem *protect; 
-    YItem *keep; 
-    YItem *dontinstall; 
+    YItem *protect;
+    YItem *keep;
+    YItem *dontinstall;
 
 
    NCPkgFilterInstSummary (YWidget *parent, std::string label, NCPackageSelector *pkg);
-   virtual ~NCPkgFilterInstSummary();   
+   virtual ~NCPkgFilterInstSummary();
 
    void createLayout();
    bool showInstSummaryPackages();

--- a/src/NCPkgFilterLocale.cc
+++ b/src/NCPkgFilterLocale.cc
@@ -60,7 +60,7 @@ NCPkgLocaleTag::NCPkgLocaleTag ( zypp::sat::LocaleSupport loc, std::string statu
 
 NCPkgLocaleTable::NCPkgLocaleTable( YWidget *parent, YTableHeader *tableHeader, NCPackageSelector *pkg )
     :NCTable( parent, tableHeader )
-    ,packager(pkg)
+    , packager(pkg)
 {
    fillHeader();
    fillLocaleList();
@@ -80,19 +80,18 @@ void NCPkgLocaleTable::fillHeader()
 
 void NCPkgLocaleTable::addLine ( zypp::sat::LocaleSupport l,  const std::vector <std::string> & cols, std::string status )
 {
-    //use default ctor, add cell in the next step
+    // use default ctor, add cell in the next step
     YTableItem *tabItem = new YTableItem();
 
-    //place tag (with repo reference) to the 0th column
+    // place tag (with repo reference) to the 0th column
     tabItem->addCell( new NCPkgLocaleTag ( l, status ) );
 
     // and append the rest (name, URL and stuff)
-    for(const std::string& s: cols) {
+    for ( const std::string& s: cols )
 	tabItem->addCell(s);
-    };
 
     // this is NCTable::addItem( tabItem );
-    //it actually appends the line to the table
+    // it actually appends the line to the table
     addItem( tabItem );
 
 }
@@ -174,7 +173,7 @@ void NCPkgLocaleTable::showLocalePackages()
     }
 
     std::ostringstream s;
-    //Translators: %s is a locale code, e.g. en_GB
+    // Translators: %s is a locale code, e.g. en_GB
     s << boost::format( _( "Translations, dictionaries and other language-related files for <b>%s</b> locale" )) % myLocale.locale().code();
     packager->FilterDescription()->setText( s.str() );
 
@@ -220,21 +219,21 @@ NCursesEvent NCPkgLocaleTable::wHandleInput( wint_t ch )
 	case KEY_NPAGE:
 	case KEY_PPAGE:
 	case KEY_END:
-	case KEY_HOME: {
+	case KEY_HOME:
 	    ret = NCursesEvent::handled;
             showLocalePackages();
 	    break;
-	}
+
 	case KEY_SPACE:
-	case KEY_RETURN: {
+	case KEY_RETURN:
 	    ret = NCursesEvent::handled;
 	    toggleStatus();
 	    showLocalePackages();
 	    break;
-	}
 
 	default:
-	    ret = NCTable::wHandleInput( ch ) ;
+	    ret = NCTable::wHandleInput( ch );
+	    break;
     }
 
     return ret;

--- a/src/NCPkgFilterLocale.h
+++ b/src/NCPkgFilterLocale.h
@@ -35,7 +35,7 @@
 
    File:       NCPkgFilterLocale.h
 
-   Author:     Bubli <kmachalkova@suse.cz> 
+   Author:     Bubli <kmachalkova@suse.cz>
 
 /-*/
 
@@ -56,12 +56,12 @@ private:
     zypp::sat::LocaleSupport locale;
 
 public:
-   
+
     NCPkgLocaleTag ( zypp::sat::LocaleSupport locale, std::string status );
 
-    ~NCPkgLocaleTag() {  };
+    ~NCPkgLocaleTag() {};
 
-    zypp::sat::LocaleSupport getLocale() const	{ return locale; } 	
+    zypp::sat::LocaleSupport getLocale() const	{ return locale; }
 
 };
 

--- a/src/NCPkgFilterMain.cc
+++ b/src/NCPkgFilterMain.cc
@@ -53,7 +53,7 @@ using std::endl;
 
 NCPkgFilterMain::NCPkgFilterMain (YWidget *parent, std::string label, NCPackageSelector *pkger )
 	:NCComboBox(parent, label, false)
-	,pkg (pkger)
+	, pkg (pkger)
 {
     createLayout();
     setNotify( true );
@@ -95,7 +95,7 @@ void NCPkgFilterMain::createLayout()
 
 }
 
-bool NCPkgFilterMain::handleEvent ( )
+bool NCPkgFilterMain::handleEvent()
 {
 
     YItem *currentItem = selectedItem();

--- a/src/NCPkgFilterMain.h
+++ b/src/NCPkgFilterMain.h
@@ -50,8 +50,8 @@
 #include "NCPackageSelector.h"
 #include "NCZypp.h"
 
-class NCPkgFilterMain : public NCComboBox {
-
+class NCPkgFilterMain : public NCComboBox
+{
     NCPkgFilterMain & operator=( const NCPkgFilterMain & );
     NCPkgFilterMain            ( const NCPkgFilterMain & );
 
@@ -65,16 +65,16 @@ public:
     YItem *rpmgroups;
     YItem *repositories;
     YItem *services;
-    YItem *search;		
-    YItem *inst_summary;		
+    YItem *search;
+    YItem *inst_summary;
     YItem *pkg_class;
-    
+
     NCPkgFilterMain (YWidget *parent, std::string label, NCPackageSelector *pkger );
     virtual ~NCPkgFilterMain();
 
     void createLayout();
 
-    bool handleEvent( );
+    bool handleEvent();
 
     void setSummarySelected() { selectItem(inst_summary); }
     void setReposSelected() { selectItem(repositories); }

--- a/src/NCPkgFilterMain.h
+++ b/src/NCPkgFilterMain.h
@@ -78,6 +78,7 @@ public:
 
     void setSummarySelected() { selectItem(inst_summary); }
     void setReposSelected() { selectItem(repositories); }
+    void setPkgClassSelected() { selectItem(pkg_class); }
 };
 
 #endif

--- a/src/NCPkgFilterPattern.cc
+++ b/src/NCPkgFilterPattern.cc
@@ -72,7 +72,7 @@ struct paircmp
 {
     bool operator() (std::pair<std::string, std::string> p1, std::pair<std::string, std::string> p2)
     {
-	if( p1.second != p2.second )
+	if ( p1.second != p2.second )
             return p1.second < p2.second;
 	else
             return ( p1.first < p2.first );
@@ -91,8 +91,8 @@ NCPkgFilterPattern::NCPkgFilterPattern( YWidget *parent, YTableHeader *header, N
     , packager( pkg )
 {
    createLayout( parent );
-   setNotify(true);
-   fillPatternList(  );
+   setNotify( true );
+   fillPatternList();
 }
 
 ///////////////////////////////////////////////////////////////////
@@ -132,10 +132,10 @@ void NCPkgFilterPattern::createLayout( YWidget *parent )
 
 ///////////////////////////////////////////////////////////////////
 //
-// NCursesEvent & showSelectionPopup ()
+// NCursesEvent & showSelectionPopup()
 //
 //
-void NCPkgFilterPattern::showPatternPackages( )
+void NCPkgFilterPattern::showPatternPackages()
 {
     int index = getCurrentItem();
     ZyppObj objPtr = getDataPointer( index );
@@ -158,7 +158,7 @@ void NCPkgFilterPattern::showPatternPackages( )
         	   yuiError() << "Widget is not a valid NCPkgTable widget" << endl;
         	   return;
             }
-            packageList->itemsCleared ();
+            packageList->itemsCleared();
 
             zypp::Pattern::Contents related ( patPtr->contents() );
             for ( zypp::Pattern::Contents::Selectable_iterator it = related.selectableBegin();
@@ -199,9 +199,9 @@ void NCPkgFilterPattern::showPatternPackages( )
 // returns the currently selected list item (may be "really" selected
 // or not)
 //
-std::string  NCPkgFilterPattern::getCurrentLine( )
+std::string  NCPkgFilterPattern::getCurrentLine()
 {
-//if ( !sel )
+// if ( !sel )
 //	return "";
 
     int index = getCurrentItem();
@@ -232,22 +232,22 @@ NCursesEvent NCPkgFilterPattern::wHandleInput( wint_t ch )
 
     switch ( ch )
     {
-    case KEY_UP:
-    case KEY_DOWN:
-    case KEY_NPAGE:
-    case KEY_PPAGE:
-    case KEY_END:
-    case KEY_HOME: {
-        ret = NCursesEvent::handled;
-        break;
+        case KEY_UP:
+        case KEY_DOWN:
+        case KEY_NPAGE:
+        case KEY_PPAGE:
+        case KEY_END:
+        case KEY_HOME:
+            ret = NCursesEvent::handled;
+            break;
+
+        default:
+            ret = NCPkgTable::wHandleInput( ch );
+            break;
     }
 
+    showPatternPackages();
 
-    default:
-       ret = NCPkgTable::wHandleInput( ch ) ;
-    }
-
-    showPatternPackages( );
     return ret;
 }
 
@@ -263,7 +263,7 @@ bool orderPattern( ZyppSel slb1, ZyppSel slb2 )
         return false;
     else
     {
-        if( ptr1->order() != ptr2->order() )
+        if ( ptr1->order() != ptr2->order() )
             return ( ptr1->order() < ptr2->order() );
 	else
             return ( ptr1->name() < ptr2->name() );
@@ -278,44 +278,44 @@ bool orderPattern( ZyppSel slb1, ZyppSel slb2 )
 //
 //	DESCRIPTION :
 //
-bool NCPkgFilterPattern::fillPatternList(  )
+bool NCPkgFilterPattern::fillPatternList()
 {
 
     ZyppPoolIterator i, b, e;
     std::map<std::string, std::list<ZyppSel> > patterns;
     std::map<std::string, std::list<ZyppSel> >::iterator mapIt;
 
-    for ( i = zyppPatternsBegin () ; i != zyppPatternsEnd ();  ++i )
+    for ( i = zyppPatternsBegin(); i != zyppPatternsEnd();  ++i )
     {
         ZyppObj resPtr = (*i)->theObj();
         bool show;
 
         ZyppPattern patPtr = tryCastToZyppPattern (resPtr);
-        show = patPtr && patPtr->userVisible ();
+        show = patPtr && patPtr->userVisible();
 
         if (show)
         {
 	    std::string cat = patPtr->category();
 
-	    //fallback category
+	    // fallback category
 	    if ( cat.empty())
 		cat = "other";
 
-	    //create "category_name" : list <patterns> std::pair
+	    // create "category_name" : list <patterns> std::pair
 	    std::map <std::string, std::list<ZyppSel> >::iterator item = patterns.find(cat);
-	    if( item == patterns.end())
+	    if ( item == patterns.end())
 	    {
 		std::list <ZyppSel> slbList;
 		slbList.push_back( (*i) );
 		yuiMilestone() << "New category added: " << cat << endl;
-		patterns.insert( make_pair (cat,slbList) );
+		patterns.insert( make_pair (cat, slbList) );
 	    }
 	    else
 	    {
 	        (*item).second.push_back( (*i));
 	    }
 
-    	    yuiMilestone() << resPtr->kind () <<": " <<  resPtr->name()
+    	    yuiMilestone() << resPtr->kind() <<": " <<  resPtr->name()
     	      << ", initial status: " << (*i)->status() << ", order: " << patPtr->order() << endl;
         }
     }
@@ -323,11 +323,11 @@ bool NCPkgFilterPattern::fillPatternList(  )
     std::set < std::pair <std::string, std::string>, paircmp > pat_index;
     std::set < std::pair <std::string, std::string>, paircmp >::iterator indexIt;
 
-    //for each category
+    // for each category
     for ( mapIt = patterns.begin(); mapIt != patterns.end(); ++mapIt )
     {
         std::string name = (*mapIt).first;
-	//sort the patterns by their order #
+	// sort the patterns by their order #
         (*mapIt).second.sort( orderPattern );
 	std::list<ZyppSel>::iterator it = (*mapIt).second.begin();
 
@@ -336,7 +336,7 @@ bool NCPkgFilterPattern::fillPatternList(  )
 	if (pat)
 	{
            yuiDebug() << "Lowest #: "<< pat->order() << endl;
-	   //create "category name" : "order #" std::pair in index structure
+	   // create "category name" : "order #" std::pair in index structure
            pat_index.insert( make_pair( name, pat->order()) );
 
 	}
@@ -345,8 +345,8 @@ bool NCPkgFilterPattern::fillPatternList(  )
     std::list<ZyppSel>::iterator listIt;
     std::vector<std::string> pkgLine;
 
-    //now retrieve patterns in defined order
-    for( indexIt = pat_index.begin(); indexIt != pat_index.end(); ++indexIt)
+    // now retrieve patterns in defined order
+    for ( indexIt = pat_index.begin(); indexIt != pat_index.end(); ++indexIt)
     {
 	std::string name = (*indexIt).first;
 	std::list<ZyppSel> slbList = patterns[name];

--- a/src/NCPkgFilterPattern.h
+++ b/src/NCPkgFilterPattern.h
@@ -57,8 +57,8 @@
 //
 //	DESCRIPTION :
 //
-class NCPkgFilterPattern : public NCPkgTable {
-
+class NCPkgFilterPattern : public NCPkgTable
+{
     NCPkgFilterPattern & operator=( const NCPkgFilterPattern & );
     NCPkgFilterPattern            ( const NCPkgFilterPattern & );
 
@@ -71,27 +71,27 @@ protected:
     std::string getCurrentLine();
 
     virtual NCursesEvent wHandleInput( wint_t ch );
-    
+
 public:
-        
+
     NCPkgFilterPattern( YWidget *parent, YTableHeader *header, NCPackageSelector * pkg );
     virtual ~NCPkgFilterPattern();
-    
+
     void createLayout( YWidget *parent );
 
     /**
      * Fills the std::list with the available selections (and the status info)
      * @return bool
      */
-    bool fillPatternList ( );
+    bool fillPatternList();
 
-    std::string showDescription( ZyppObj objPtr );	
-   
+    std::string showDescription( ZyppObj objPtr );
+
     /**
      * Shows the popup with the add ons (package categories).
      * @return NCursesEvent
      */
-    void showPatternPackages( );
+    void showPatternPackages();
 
 };
 

--- a/src/NCPkgFilterRepo.cc
+++ b/src/NCPkgFilterRepo.cc
@@ -83,7 +83,7 @@ NCPkgRepoTag::NCPkgRepoTag ( ZyppRepo repoPtr)
 
 NCPkgRepoTable::NCPkgRepoTable( YWidget *parent, YTableHeader *tableHeader, NCPackageSelector *pkg )
     :NCTable( parent, tableHeader )
-    ,packager(pkg)
+    , packager(pkg)
 {
    fillHeader();
    fillRepoList();
@@ -120,19 +120,18 @@ void NCPkgRepoTable::fillHeader()
 
 void NCPkgRepoTable::addLine ( ZyppRepo r, const std::vector <std::string> & cols )
 {
-    //use default ctor, add cell in the next step
+    // use default ctor, add cell in the next step
     YTableItem *tabItem = new YTableItem();
 
-    //place tag (with repo reference) to the 0th column
+    // place tag (with repo reference) to the 0th column
     tabItem->addCell( new NCPkgRepoTag ( r ) );
 
     // and append the rest (name, URL and stuff)
-    for(const std::string& s: cols) {
+    for ( const std::string& s: cols )
 	tabItem->addCell(s);
-    };
 
     // this is NCTable::addItem( tabItem );
-    //it actually appends the line to the table
+    // it actually appends the line to the table
     addItem( tabItem );
 
 
@@ -158,7 +157,7 @@ NCPkgRepoTag* NCPkgRepoTable::getTag (const int & index )
 
    YTableItem *it = dynamic_cast<YTableItem*> (line->origItem() );
 
-   //get actual repo tag from 0th column of the table
+   // get actual repo tag from 0th column of the table
    YTableCell *tcell = it->cell(0);
    NCPkgRepoTag *tag = static_cast<NCPkgRepoTag *>( tcell );
 
@@ -180,7 +179,7 @@ ZyppRepo NCPkgRepoTable::getRepo( int index )
 
     if ( !t )
     {
-	return ZyppRepo( );
+	return ZyppRepo();
     }
     else
     {
@@ -222,7 +221,7 @@ bool NCPkgRepoTable::fillRepoList()
 
     std::vector <std::string> oneLine;
 
-    //iterate through all repositories
+    // iterate through all repositories
     for ( ZyppRepositoryIterator it = ZyppRepositoriesBegin();
 	  it != ZyppRepositoriesEnd();
           ++it)
@@ -231,8 +230,8 @@ bool NCPkgRepoTable::fillRepoList()
 
 	// let's find some product for this repository
         // but not now :) bug #296782
-	//ZyppProduct product = findProductForRepo( (*it) );
-        //if ( product )
+	// ZyppProduct product = findProductForRepo( (*it) );
+        // if ( product )
 	//{
 	//  name = product->summary();
         //}
@@ -245,7 +244,7 @@ bool NCPkgRepoTable::fillRepoList()
     return true;
 }
 
-bool NCPkgRepoTable::showRepoPackages( )
+bool NCPkgRepoTable::showRepoPackages()
 {
     int index = getCurrentItem();
     ZyppRepo repo = getRepo( index );
@@ -254,14 +253,14 @@ bool NCPkgRepoTable::showRepoPackages( )
     yuiMilestone() << "Collecting packages in selected repository" << endl;
 
     NCPkgTable *pkgList = packager->PackageList();
-    //clean the pkg table first
-    pkgList->itemsCleared ();
+    // clean the pkg table first
+    pkgList->itemsCleared();
 
     zypp::PoolQuery q;
     q.addRepo( repo.info().alias() );
     q.addKind( zypp::ResKind::package );
 
-    for( zypp::PoolQuery::Selectable_iterator it = q.selectableBegin();
+    for ( zypp::PoolQuery::Selectable_iterator it = q.selectableBegin();
 	it != q.selectableEnd(); it++)
     {
         ZyppPkg pkg = tryCastToZyppPkg( (*it)->theObj() );
@@ -297,7 +296,7 @@ ZyppProduct NCPkgRepoTable::findProductForRepo( ZyppRepo repo)
 
     while( beg != end && !product )
     {
-	//Single product - most common case
+	// Single product - most common case
 	if ( beg->resolvable()->repoInfo().alias() == repo.info().alias() )
             product = zypp::asKind<zypp::Product>( beg->resolvable() );
         beg++;
@@ -307,7 +306,7 @@ ZyppProduct NCPkgRepoTable::findProductForRepo( ZyppRepo repo)
     {
 	if ( beg->resolvable()->repoInfo().alias() == repo.info().alias() )
         {
-	    //Aw, multiple product found, we don't want those
+	    // Aw, multiple product found, we don't want those
             yuiWarning() << "Multiple products in repository " <<
                      repo.info().alias().c_str() << endl;
             ZyppProduct null;
@@ -319,7 +318,7 @@ ZyppProduct NCPkgRepoTable::findProductForRepo( ZyppRepo repo)
 
    if ( !product )
    {
-	//bad luck, nothing found
+	// bad luck, nothing found
 	yuiMilestone() << "No product in repository " <<
                  repo.info().alias().c_str() << endl;
    }
@@ -348,15 +347,15 @@ NCursesEvent NCPkgRepoTable::wHandleInput( wint_t ch )
 	case KEY_NPAGE:
 	case KEY_PPAGE:
 	case KEY_END:
-	case KEY_HOME: {
+	case KEY_HOME:
 	    ret = NCursesEvent::handled;
             showRepoPackages();
 	    break;
-	}
 
 	default:
-	   ret = NCTable::wHandleInput( ch ) ;
-     }
+            ret = NCTable::wHandleInput( ch );
+	    break;
+    }
 
     return ret;
 }

--- a/src/NCPkgFilterRepo.h
+++ b/src/NCPkgFilterRepo.h
@@ -35,7 +35,7 @@
 
    File:       NCPkgFilterRepo.h
 
-   Author:     Bubli <kmachalkova@suse.cz> 
+   Author:     Bubli <kmachalkova@suse.cz>
 
 /-*/
 
@@ -76,16 +76,16 @@ public:
 
     NCPkgRepoTag ( ZyppRepo repo);
 
-    //Nikdy, ale opravdu nikdy nenechavej v odvozene tride virtualni
-    //destruktor, kdyz ani v puvodni neni, Bublino!
-    ~NCPkgRepoTag() {  };
+    // Nikdy, ale opravdu nikdy nenechavej v odvozene tride virtualni
+    // destruktor, kdyz ani v puvodni neni, Bublino!
+    ~NCPkgRepoTag() {};
 
     /*
      * Get repository reference from the line tag
      * @return ZyppRepo
      */
 
-    ZyppRepo getRepo() const		{ return repo; } 	
+    ZyppRepo getRepo() const		{ return repo; }
 
 };
 
@@ -131,7 +131,7 @@ public:
     NCPkgRepoTag * getTag ( const int & index );
 
     /**
-     * Get repository reference from selected line's tag 
+     * Get repository reference from selected line's tag
      * @param index Index of selected table line
      * @return ZyppRepo Associated zypp::Repository reference
      */
@@ -153,11 +153,11 @@ public:
    /**
       * Add items to the repository list (assoc.
       * product name, if any, and URL)
-      * @return bool (always true ;-) )
+      * @return bool (always true;-) )
       */
-    bool fillRepoList( );
+    bool fillRepoList();
 
-    bool showRepoPackages( );
+    bool showRepoPackages();
 
 };
 #endif

--- a/src/NCPkgFilterSearch.cc
+++ b/src/NCPkgFilterSearch.cc
@@ -111,12 +111,12 @@ void NCPkgFilterSearch::createLayout( YWidget *parent )
 
     // add the input field (a editable combo box)
     NCLayoutBox * vSplit = new NCLayoutBox ( frame0, YD_VERT);
-    //new NCSpacing( vSplit, YD_VERT, true, 0.5 );
+    // new NCSpacing( vSplit, YD_VERT, true, 0.5 );
 
     searchExpr = new NCInputField( vSplit, NCPkgStrings::SearchPhrase() );
     searchExpr->setStretchable( YD_HORIZ, true );
 
-    //new NCSpacing( vSplit, YD_VERT, false, 0.5 );
+    // new NCSpacing( vSplit, YD_VERT, false, 0.5 );
 
     if ( !packager->isYouMode() )
     {
@@ -155,7 +155,7 @@ std::string  NCPkgFilterSearch::getSearchExpression() const
 	// value = searchExpr->getValue();
 
 	value = searchExpr->value();
-	//searchExpr->addItem( value, true );
+	// searchExpr->addItem( value, true );
     }
 
     return value;
@@ -192,7 +192,7 @@ bool NCPkgFilterSearch::fillSearchList( std::string & expr,
     }
 
     // clear the package table
-    packageList->itemsCleared ();
+    packageList->itemsCleared();
 
     NCPkgSearchSettings *settings = packager->SearchSettings();
     zypp::PoolQuery q;
@@ -245,7 +245,7 @@ bool NCPkgFilterSearch::fillSearchList( std::string & expr,
 
     try
     {
-	for( zypp::PoolQuery::Selectable_iterator it = q.selectableBegin();
+	for ( zypp::PoolQuery::Selectable_iterator it = q.selectableBegin();
 	     it != q.selectableEnd(); it++)
 	{
 	    ZyppPkg pkg = tryCastToZyppPkg( (*it)->theObj() );
@@ -264,7 +264,7 @@ bool NCPkgFilterSearch::fillSearchList( std::string & expr,
 	info->setPreferredSize( 50, 10 );
 	info->showInfoPopup();
 	YDialog::deleteTopmostDialog();
-	yuiError() << "Caught a std::exception: " << e.what () << endl;
+	yuiError() << "Caught a std::exception: " << e.what() << endl;
     }
 
     info->popdown();

--- a/src/NCPkgFilterSearch.h
+++ b/src/NCPkgFilterSearch.h
@@ -64,14 +64,15 @@ class NCPackageSelector;
 //
 //	DESCRIPTION :
 //
-class NCPkgFilterSearch : public NCLayoutBox {
-
+class NCPkgFilterSearch : public NCLayoutBox
+{
     NCPkgFilterSearch & operator=( const NCPkgFilterSearch & );
     NCPkgFilterSearch            ( const NCPkgFilterSearch & );
 
 private:
 
-    enum SearchMode {
+    enum SearchMode
+    {
 	Contains = 0,
 	BeginsWith,
 	ExactMatch,
@@ -104,7 +105,7 @@ public:
 
     bool fillSearchList( std::string & expr, bool ignoreCase );
 
-    NCInputField * getSearchField() { return searchExpr; } 
+    NCInputField * getSearchField() { return searchExpr; }
 
 };
 

--- a/src/NCPkgFilterService.cc
+++ b/src/NCPkgFilterService.cc
@@ -69,8 +69,8 @@ NCPkgServiceTag::NCPkgServiceTag ( ZyppService servicePtr)
 
 NCPkgServiceTable::NCPkgServiceTable( YWidget *parent, YTableHeader *tableHeader, NCPackageSelector *pkg )
     :NCTable( parent, tableHeader )
-    ,packager(pkg)
-    ,repo_manager(new zypp::RepoManager())
+    , packager(pkg)
+    , repo_manager(new zypp::RepoManager())
 {
    fillHeader();
    fillServiceList();
@@ -83,7 +83,7 @@ bool NCPkgServiceTable::any_service()
         return !repo.info().service().empty();
     });
 
-    yuiMilestone() << "Found a libzypp service: " << ret << std::endl;
+    yuiMilestone() << "Found a libzypp service: " << ret << endl;
     return ret;
 }
 
@@ -118,22 +118,19 @@ void NCPkgServiceTable::fillHeader()
 
 void NCPkgServiceTable::addLine ( ZyppService svc, const std::vector <std::string> & cols )
 {
-    //use default ctor, add cell in the next step
+    // use default ctor, add cell in the next step
     YTableItem *tabItem = new YTableItem();
 
-    //place tag (with service reference) to the 0th column
-    tabItem->addCell( new NCPkgServiceTag (svc) );
+    // place tag (with service reference) to the 0th column
+    tabItem->addCell( new NCPkgServiceTag( svc ) );
 
     // and append the rest (name, URL and stuff)
-    for(const std::string& s: cols) {
+    for ( const std::string& s: cols )
 	tabItem->addCell(s);
-    };
 
     // this is NCTable::addItem( tabItem );
-    //it actually appends the line to the table
+    // it actually appends the line to the table
     addItem( tabItem );
-
-
 }
 
 ///////////////////////////////////////////////////////////////////
@@ -156,7 +153,7 @@ NCPkgServiceTag* NCPkgServiceTable::getTag (int index)
 
    YTableItem *it = line->origItem();
 
-   //get actual service tag from 0th column of the table
+   // get actual service tag from 0th column of the table
    YTableCell *tcell = it->cell(0);
    NCPkgServiceTag *tag = static_cast<NCPkgServiceTag *>( tcell );
 
@@ -231,7 +228,7 @@ bool NCPkgServiceTable::fillServiceList()
     return true;
 }
 
-void NCPkgServiceTable::showServicePackages( )
+void NCPkgServiceTable::showServicePackages()
 {
     int index = getCurrentItem();
     ZyppService service = getService( index );
@@ -240,8 +237,8 @@ void NCPkgServiceTable::showServicePackages( )
     yuiMilestone() << "Collecting packages in selected service" << endl;
 
     NCPkgTable *pkgList = packager->PackageList();
-    //clean the pkg table first
-    pkgList->itemsCleared ();
+    // clean the pkg table first
+    pkgList->itemsCleared();
 
     zypp::PoolQuery query;
     query.addKind( zypp::ResKind::package );
@@ -250,13 +247,14 @@ void NCPkgServiceTable::showServicePackages( )
     {
         if (service == repo.info().service())
         {
-          yuiMilestone() << "Adding repo filter: " << repo.info().alias() << std::endl;
+          yuiMilestone() << "Adding repo filter: " << repo.info().alias() << endl;
           query.addRepo( repo.info().alias() );
         }
     });
 
-    for( zypp::PoolQuery::Selectable_iterator it = query.selectableBegin();
-	it != query.selectableEnd(); it++)
+    for ( zypp::PoolQuery::Selectable_iterator it = query.selectableBegin();
+          it != query.selectableEnd();
+          it++)
     {
         ZyppPkg pkg = tryCastToZyppPkg( (*it)->theObj() );
         pkgList->createListEntry ( pkg, *it);
@@ -290,15 +288,15 @@ NCursesEvent NCPkgServiceTable::wHandleInput( wint_t ch )
 	case KEY_NPAGE:
 	case KEY_PPAGE:
 	case KEY_END:
-	case KEY_HOME: {
+	case KEY_HOME:
 	    ret = NCursesEvent::handled;
             showServicePackages();
 	    break;
-	}
 
 	default:
-	   ret = NCTable::wHandleInput( ch ) ;
-     }
+            ret = NCTable::wHandleInput( ch );
+            break;
+    }
 
     return ret;
 }

--- a/src/NCPkgFilterService.h
+++ b/src/NCPkgFilterService.h
@@ -60,16 +60,16 @@ public:
       * @param service zypp::Service reference
       */
 
-    NCPkgServiceTag ( ZyppService service);
+    NCPkgServiceTag( ZyppService service );
 
-    ~NCPkgServiceTag() {  };
+    ~NCPkgServiceTag() {};
 
     /*
      * Get service reference from the line tag
      * @return ZyppService
      */
 
-    ZyppService getService() const		{ return service; } 	
+    ZyppService getService() const		{ return service; }
 
 };
 
@@ -123,7 +123,7 @@ public:
     NCPkgServiceTag * getTag ( int index );
 
     /**
-     * Get service reference from selected line's tag 
+     * Get service reference from selected line's tag
      * @param index Index of selected table line
      * @return ZyppService Associated zypp::Service reference
      */
@@ -139,15 +139,15 @@ public:
    /**
       * Add items to the service list (assoc.
       * product name, if any, and URL)
-      * @return bool (always true ;-) )
+      * @return bool (always true;-) )
       */
-    bool fillServiceList( );
+    bool fillServiceList();
 
     /**
      * Make the Package List show the packages
      * for the currently selected service
      */
-    void showServicePackages( );
+    void showServicePackages();
 
 };
 #endif

--- a/src/NCPkgMenuAction.cc
+++ b/src/NCPkgMenuAction.cc
@@ -52,7 +52,7 @@ using std::endl;
 
 NCPkgMenuAction::NCPkgMenuAction (YWidget *parent, std::string label, NCPackageSelector *pkger)
 	: NCMenuButton( parent, label)
-	,pkg( pkger )
+	, pkg( pkger )
 {
     createLayout();
 }

--- a/src/NCPkgMenuAction.h
+++ b/src/NCPkgMenuAction.h
@@ -51,8 +51,8 @@
 
 class NCPackageSelector;
 
-class NCPkgMenuAction : public NCMenuButton {
-
+class NCPkgMenuAction : public NCMenuButton
+{
     NCPkgMenuAction & operator=( const NCPkgMenuAction & );
     NCPkgMenuAction            ( const NCPkgMenuAction & );
 
@@ -68,20 +68,20 @@ public:
     YMenuItem *updateItem;
     YMenuItem *tabooItem;
     YMenuItem *lockItem;
-    YMenuItem *allItem;	
+    YMenuItem *allItem;
 
-    YMenuItem *installAllItem;	
-    YMenuItem *deleteAllItem;	
-    YMenuItem *keepAllItem;	
-    YMenuItem *updateAllItem;	
-    YMenuItem *updateNewerItem;	
+    YMenuItem *installAllItem;
+    YMenuItem *deleteAllItem;
+    YMenuItem *keepAllItem;
+    YMenuItem *updateAllItem;
+    YMenuItem *updateNewerItem;
 
     NCPkgMenuAction (YWidget *parent, std::string label, NCPackageSelector *pkger);
     virtual ~NCPkgMenuAction();
 
     void createLayout();
 
-    bool handleEvent (const NCursesEvent & event);		
+    bool handleEvent (const NCursesEvent & event);
 
 };
 

--- a/src/NCPkgMenuConfig.cc
+++ b/src/NCPkgMenuConfig.cc
@@ -55,7 +55,7 @@ using std::endl;
 
 NCPkgMenuConfig::NCPkgMenuConfig (YWidget *parent, std::string label, NCPackageSelector *pkger)
 	: NCMenuButton( parent, label)
-	,pkg( pkger )
+	, pkg( pkger )
 {
     createLayout();
 }
@@ -69,7 +69,7 @@ void NCPkgMenuConfig::setSelected( YMenuItem *item, bool selected)
 {
     std::string oldLabel = item->label();
 
-    std::string newLabel = oldLabel.replace(1,1,1, selected ? 'x' : ' ');
+    std::string newLabel = oldLabel.replace(1, 1, 1, selected ? 'x' : ' ');
 
     item->setLabel( newLabel);
 }
@@ -90,7 +90,7 @@ void NCPkgMenuConfig::createLayout()
 	items.push_back( actionOnExit );
 
 	restart = new YMenuItem( actionOnExit, CHECK_BOX + _( "&Restart Package Manager" ) );
-	close = new YMenuItem( actionOnExit,CHECK_BOX +  _( "&Close Package Manager" ) );
+	close = new YMenuItem( actionOnExit, CHECK_BOX +  _( "&Close Package Manager" ) );
 	showSummary = new YMenuItem( actionOnExit, CHECK_BOX +  _( "&Show Summary" ) );
 
 	idToItemPtr["restart"] = restart;
@@ -111,16 +111,16 @@ bool NCPkgMenuConfig::handleEvent( const NCursesEvent & event)
 
     if ( event.selection == repoManager )
     {
-	//return `repo_mgr symbol to YCP module (FaTE #302517)
+	// return `repo_mgr symbol to YCP module (FaTE #302517)
 	const_cast<NCursesEvent &>(event).result = "repo_mgr";
 	yuiMilestone() << "Launching repository manager " << endl;
 
-        //and close the main loop
+        // and close the main loop
 	return false;
     }
     else if ( event.selection == onlineUpdate )
     {
-	//the same as above, return `online_update_config
+	// the same as above, return `online_update_config
 	const_cast<NCursesEvent &>(event).result = "online_update_configuration";
 	yuiMilestone() << "Launching YOU configuration " << endl;
 

--- a/src/NCPkgMenuConfig.h
+++ b/src/NCPkgMenuConfig.h
@@ -54,8 +54,8 @@
 class NCPackageSelector;
 
 
-class NCPkgMenuConfig : public NCMenuButton {
-
+class NCPkgMenuConfig : public NCMenuButton
+{
     NCPkgMenuConfig & operator=( const NCPkgMenuConfig & );
     NCPkgMenuConfig            ( const NCPkgMenuConfig & );
 

--- a/src/NCPkgMenuDeps.cc
+++ b/src/NCPkgMenuDeps.cc
@@ -69,11 +69,11 @@ void NCPkgMenuDeps::setSelected( YMenuItem *item, bool selected)
 {
     std::string oldLabel = item->label();
     char sel = 'x';
-    
+
     if ( item == cleanDepsOnRemove || item == allowVendorChange )
         sel = '+';
-            
-    std::string newLabel = oldLabel.replace(1,1,1, selected ? sel : ' ');
+
+    std::string newLabel = oldLabel.replace(1, 1, 1, selected ? sel : ' ');
 
     item->setLabel( newLabel);
 }
@@ -185,7 +185,7 @@ bool NCPkgMenuDeps::doInstallRecommended()
     pkg->saveState();
     pkg->doInstallRecommended (  &ok );
 
-    //display the popup with automatic changes
+    // display the popup with automatic changes
     NCPkgPopupTable * autoChangePopup =
         new NCPkgPopupTable( wpos( 3, 8 ), pkg,
                              // headline of a popup with packages
@@ -279,10 +279,10 @@ bool NCPkgMenuDeps::verify()
     yuiMilestone() << "Verifying system" << endl;
 
     pkg->saveState();
-    //call the solver (with S_Verify it displays no popup)
+    // call the solver (with S_Verify it displays no popup)
     pkg->systemVerification( &ok );
 
-    //display the popup with automatic changes
+    // display the popup with automatic changes
     NCPkgPopupTable * autoChangePopup =
         new NCPkgPopupTable( wpos( 3, 8 ), pkg,
                              // headline of a popup with packages

--- a/src/NCPkgMenuDeps.h
+++ b/src/NCPkgMenuDeps.h
@@ -52,8 +52,8 @@
 
 class NCPackageSelector;
 
-class NCPkgMenuDeps : public NCMenuButton {
-
+class NCPkgMenuDeps : public NCMenuButton
+{
     NCPkgMenuDeps & operator=( const NCPkgMenuDeps & );
     NCPkgMenuDeps            ( const NCPkgMenuDeps & );
 
@@ -71,14 +71,14 @@ public:
     YMenuItem *installRecommendedNow;
     YMenuItem *cleanDepsOnRemove;
     YMenuItem *allowVendorChange;
-    YMenuItem *testCase;	
+    YMenuItem *testCase;
 
     NCPkgMenuDeps (YWidget *parent, std::string label, NCPackageSelector *pkger);
     virtual ~NCPkgMenuDeps();
 
     void createLayout();
 
-    bool handleEvent (const NCursesEvent & event);		
+    bool handleEvent (const NCursesEvent & event);
 
     bool checkDependencies();
 

--- a/src/NCPkgMenuExtras.cc
+++ b/src/NCPkgMenuExtras.cc
@@ -100,11 +100,11 @@ bool NCPkgMenuExtras::handleEvent ( const NCursesEvent & event)
 	showDiskSpace();
     /*else if ( event.selection == repoManager )
     {
-	//return `repo_mgr symbol to YCP module (FaTE #302517)
+	// return `repo_mgr symbol to YCP module (FaTE #302517)
 	const_cast<NCursesEvent &>(event).result = "repo_mgr";
 	yuiMilestone() << "Launching repository manager " << endl;
 
-        //and close the main loop
+        // and close the main loop
 	return false;
     }*/
     return true;
@@ -115,12 +115,12 @@ void NCPkgMenuExtras::importSelectable( ZyppSel selectable, bool isWanted, const
     ZyppStatus oldStatus = selectable->status();
     ZyppStatus newStatus = oldStatus;
 
-    //Package/Pattern is on the list
+    // Package/Pattern is on the list
     if (isWanted)
     {
 	switch (oldStatus)
 	{
-	    //Keep status for installed ones
+	    // Keep status for installed ones
 	    case S_Install:
 	    case S_AutoInstall:
 	    case S_Update:
@@ -130,14 +130,14 @@ void NCPkgMenuExtras::importSelectable( ZyppSel selectable, bool isWanted, const
 		newStatus = oldStatus;
 		break;
 
-	    //Keep also those marked for deletion
+	    // Keep also those marked for deletion
 	    case S_Del:
 	    case S_AutoDel:
 		newStatus = S_KeepInstalled;
 		yuiDebug() << "Keeping " << kind << " " << selectable->name().c_str() << endl;
 		break;
 
-	    //Add not yet installed pkgs (if they have candidate available)
+	    // Add not yet installed pkgs (if they have candidate available)
 	    case S_NoInst:
 	    case S_Taboo:
 		if ( selectable->hasCandidateObj() )
@@ -153,12 +153,12 @@ void NCPkgMenuExtras::importSelectable( ZyppSel selectable, bool isWanted, const
 		break;
 	}
     }
-    //Package/Pattern is not on the list
+    // Package/Pattern is not on the list
     else
     {
 	switch (oldStatus)
 	{
-	    //Mark installed ones for deletion
+	    // Mark installed ones for deletion
 	    case S_Install:
 	    case S_AutoInstall:
 	    case S_Update:
@@ -169,7 +169,7 @@ void NCPkgMenuExtras::importSelectable( ZyppSel selectable, bool isWanted, const
 		yuiDebug() << "Deleting " << kind << " " << selectable->name().c_str() << endl;
 		break;
 
-            //Keep status for not installed, taboo and to-be-deleted
+            // Keep status for not installed, taboo and to-be-deleted
 	    case S_Del:
 	    case S_AutoDel:
 	    case S_NoInst:
@@ -185,7 +185,7 @@ void NCPkgMenuExtras::importSelectable( ZyppSel selectable, bool isWanted, const
 
 
 bool NCPkgMenuExtras::exportToFile()
-{	//Ask for file to save into
+{	// Ask for file to save into
     std::string filename = YUI::app()->askForSaveFileName( DEFAULT_EXPORT_FILE_NAME,
     						  "*.xml",
     						  _( "Export List of All Packages and Patterns to File" ));
@@ -195,7 +195,7 @@ bool NCPkgMenuExtras::exportToFile()
         zypp::syscontent::Writer writer;
         const zypp::ResPool & pool = zypp::getZYpp()->pool();
 
-        //some strange C++ magic (c) by ma
+        // some strange C++ magic (c) by ma
         for_each( pool.begin(), pool.end(),
     	boost::bind( &zypp::syscontent::Writer::addIf,
     		     boost::ref(writer),
@@ -203,7 +203,7 @@ bool NCPkgMenuExtras::exportToFile()
 
         try
         {
-    	    //open file for writing and try to dump syscontent into it
+    	    // open file for writing and try to dump syscontent into it
     	    std::ofstream exportFile(  filename.c_str() );
     	    exportFile.exceptions(std::ios_base::badbit | std::ios_base::failbit );
     	    exportFile << writer;
@@ -215,10 +215,10 @@ bool NCPkgMenuExtras::exportToFile()
         {
     	    yuiWarning() << "Error exporting list of packages and patterns to " << filename << endl;
 
-    	    //delete partially written file (don't care if it doesn't exist)
+    	    // delete partially written file (don't care if it doesn't exist)
     	    (void) unlink( filename.c_str() );
 
-    	    //present error popup to the user
+    	    // present error popup to the user
     	    NCPopupInfo * errorMsg = new NCPopupInfo( wpos( (NCurses::lines()-5)/2, (NCurses::cols()-40)/2 ),
     	    					  NCPkgStrings::ErrorLabel(),
     	    					  _( "Error exporting list of packages and patterns to " )
@@ -226,7 +226,7 @@ bool NCPkgMenuExtras::exportToFile()
     	    					  + filename,
     	    					  NCPkgStrings::OKLabel(),
     	    					  "");
-            errorMsg->setPreferredSize(40,5);
+            errorMsg->setPreferredSize(40, 5);
     	    NCursesEvent input = errorMsg->showInfoPopup();
 
     	    YDialog::deleteTopmostDialog();
@@ -240,7 +240,7 @@ bool NCPkgMenuExtras::exportToFile()
 
 bool NCPkgMenuExtras::importFromFile()
 {
-    //ask for file to open
+    // ask for file to open
     std::string filename = YUI::app()->askForExistingFile( DEFAULT_EXPORT_FILE_NAME,
     						  "*.xml",
     						  _( "Import List of All Packages and Patterns from File" ));
@@ -254,11 +254,11 @@ bool NCPkgMenuExtras::importFromFile()
     	std::ifstream importFile ( filename.c_str() );
     	zypp::syscontent::Reader reader (importFile);
 
-    	//maps to store package/pattern data into
+    	// maps to store package/pattern data into
     	std::map<std::string, ZyppReaderEntry> importPkgs;
     	std::map<std::string, ZyppReaderEntry> importPatterns;
 
-    	//Import syscontent reader to a map $[ "package_name" : pointer_to_data]
+    	// Import syscontent reader to a map $[ "package_name" : pointer_to_data]
     	for (zypp::syscontent::Reader::const_iterator it = reader.begin();
     	     it != reader.end();
     	     it ++ )
@@ -274,13 +274,13 @@ bool NCPkgMenuExtras::importFromFile()
 
     	yuiMilestone() << "Found " << importPkgs.size() << " packages and " << importPatterns.size() << " patterns." << endl;
 
-    	//Change status of appropriate packages and patterns
+    	// Change status of appropriate packages and patterns
     	for (ZyppPoolIterator it = zyppPkgBegin();
     	     it != zyppPkgEnd();
     	     it++ )
     	{
     	    ZyppSel selectable = *it;
-    	    //isWanted => package name found in importPkgs map
+    	    // isWanted => package name found in importPkgs map
     	    importSelectable ( *it, importPkgs.find( selectable->name() ) != importPkgs.end(), "package" );
     	}
 
@@ -292,7 +292,7 @@ bool NCPkgMenuExtras::importFromFile()
     	    importSelectable ( *it, importPatterns.find( selectable->name() ) != importPatterns.end(), "pattern" );
     	}
 
-    	//Switch to installation summary filter
+    	// Switch to installation summary filter
     	packageList->fillSummaryList(NCPkgTable::L_Changes);
 
     	//... and finally display the result
@@ -312,7 +312,7 @@ bool NCPkgMenuExtras::importFromFile()
     						  + filename,
     						  NCPkgStrings::OKLabel(),
     						  "");
-        errorMsg->setPreferredSize(40,5);
+        errorMsg->setPreferredSize(40, 5);
     	NCursesEvent input = errorMsg->showInfoPopup();
 
     	YDialog::deleteTopmostDialog();
@@ -325,7 +325,7 @@ bool NCPkgMenuExtras::importFromFile()
 bool NCPkgMenuExtras::showDiskSpace()
 {
       pkg->diskSpacePopup()->showInfoPopup( NCPkgStrings::DiskspaceLabel() );
-    //FIXME: move focus back to pkg table?
+    // FIXME: move focus back to pkg table?
 
     return true;
 }

--- a/src/NCPkgMenuExtras.h
+++ b/src/NCPkgMenuExtras.h
@@ -54,8 +54,8 @@
 class NCPackageSelector;
 
 
-class NCPkgMenuExtras : public NCMenuButton {
-
+class NCPkgMenuExtras : public NCMenuButton
+{
     NCPkgMenuExtras & operator=( const NCPkgMenuExtras & );
     NCPkgMenuExtras            ( const NCPkgMenuExtras & );
 
@@ -77,12 +77,12 @@ public:
     bool handleEvent (const NCursesEvent & event);
 
     void importSelectable ( ZyppSel selectable, bool isWanted, const char*kind );
- 
+
     bool exportToFile();
 
     bool importFromFile();
 
-    bool showDiskSpace();		
+    bool showDiskSpace();
 
 };
 

--- a/src/NCPkgMenuFilter.cc
+++ b/src/NCPkgMenuFilter.cc
@@ -54,7 +54,7 @@ using std::endl;
 
 NCPkgMenuFilter::NCPkgMenuFilter (YWidget *parent, std::string label, NCPackageSelector *pkger)
     : NCMenuButton( parent, label)
-    ,pkg (pkger)
+    , pkg (pkger)
 {
     createLayout();
 }
@@ -136,7 +136,7 @@ bool NCPkgMenuFilter::handleEvent ( const NCursesEvent & event)
 	    if ( retEvent == NCursesEvent::button )
 	    {
 		yuiMilestone() << "Searching for: " <<  retEvent.result << endl;
-		pkgList->showInformation( );
+		pkgList->showInformation();
 	    }
 	    else
 	    {
@@ -149,7 +149,7 @@ bool NCPkgMenuFilter::handleEvent ( const NCursesEvent & event)
 
     pkgList->setKeyboardFocus();
 
-    pkgList->showInformation( );
+    pkgList->showInformation();
 
     return true;
 }

--- a/src/NCPkgMenuFilter.h
+++ b/src/NCPkgMenuFilter.h
@@ -54,10 +54,11 @@ class NCPackageSelector;
 
 #include "NCZypp.h"
 
-class NCPkgMenuFilter : public NCMenuButton {
-
+class NCPkgMenuFilter : public NCMenuButton
+{
 public:
-	enum PatchFilter 
+
+	enum PatchFilter
 	{
 	    F_Needed,
 	    F_Unneeded,
@@ -67,13 +68,13 @@ public:
 	    F_Optional,
 	    F_Unknown
 	};
-    
+
     NCPkgMenuFilter & operator=( const NCPkgMenuFilter & );
     NCPkgMenuFilter            ( const NCPkgMenuFilter & );
 
 private:
     NCPackageSelector *pkg;
-    
+
     NCPkgPatchSearch *searchPopup;
 
     YItemCollection items;
@@ -81,19 +82,20 @@ private:
     YMenuItem *needed;
     YMenuItem *unneeded;
     YMenuItem *allPatches;
-    YMenuItem *recommended;	
+    YMenuItem *recommended;
     YMenuItem *security;
     YMenuItem *optional;
     YMenuItem *search;
 
+
 public:
-    
+
     NCPkgMenuFilter (YWidget *parent, std::string label, NCPackageSelector *pkger);
     virtual ~NCPkgMenuFilter();
 
     void createLayout();
 
-    bool handleEvent (const NCursesEvent & event);		
+    bool handleEvent (const NCursesEvent & event);
 
 };
 

--- a/src/NCPkgMenuHelp.cc
+++ b/src/NCPkgMenuHelp.cc
@@ -80,7 +80,8 @@ void NCPkgMenuHelp::createLayout()
         menuHelp = new YMenuItem( _( "&Useful Functions in Menu" ) );
         items.push_back( menuHelp );
     }
-    else {
+    else
+    {
 	patchHelp = new YMenuItem( _( "&Patch Status and Patch Installation" ));
 	items.push_back ( patchHelp );
     }
@@ -153,7 +154,7 @@ bool NCPkgMenuHelp::handleEvent ( const NCursesEvent & event)
 					     text
 					     );
     pkgHelp->setPreferredSize( (NCurses::cols()*65)/100, (NCurses::lines()*85)/100 );
-    pkgHelp->showInfoPopup( );
+    pkgHelp->showInfoPopup();
 
     YDialog::deleteTopmostDialog();
 

--- a/src/NCPkgMenuHelp.h
+++ b/src/NCPkgMenuHelp.h
@@ -49,10 +49,10 @@
 #include "NCPopupInfo.h"
 #include "NCZypp.h"
 
-class NCPackageSelector; 
+class NCPackageSelector;
 
-class NCPkgMenuHelp : public NCMenuButton {
-
+class NCPkgMenuHelp : public NCMenuButton
+{
     NCPkgMenuHelp & operator=( const NCPkgMenuHelp & );
     NCPkgMenuHelp            ( const NCPkgMenuHelp & );
 

--- a/src/NCPkgMenuView.cc
+++ b/src/NCPkgMenuView.cc
@@ -52,7 +52,7 @@ using std::endl;
 
 NCPkgMenuView::NCPkgMenuView (YWidget *parent, std::string label, NCPackageSelector *pkger)
 	: NCMenuButton( parent, label)
-        ,pkg (pkger)
+        , pkg (pkger)
 {
     createLayout();
 }

--- a/src/NCPkgMenuView.h
+++ b/src/NCPkgMenuView.h
@@ -52,8 +52,8 @@
 
 class NCPackageSelector;
 
-class NCPkgMenuView : public NCMenuButton {
-
+class NCPkgMenuView : public NCMenuButton
+{
     NCPkgMenuView & operator=( const NCPkgMenuView & );
     NCPkgMenuView            ( const NCPkgMenuView & );
 
@@ -67,20 +67,20 @@ public:
     YMenuItem *description;
     YMenuItem *technical;
     YMenuItem *versions;
-    YMenuItem *files;	
-    YMenuItem *deps;	
+    YMenuItem *files;
+    YMenuItem *deps;
 
     // Online Update
     YMenuItem * patchDescription;
     YMenuItem * patchPackages;
     YMenuItem * patchPkgVersions;
-    
+
     NCPkgMenuView (YWidget *parent, std::string label, NCPackageSelector *pkger);
     virtual ~NCPkgMenuView();
 
     void createLayout();
 
-    bool handleEvent (const NCursesEvent & event);		
+    bool handleEvent (const NCursesEvent & event);
 
 };
 

--- a/src/NCPkgPackageDetails.cc
+++ b/src/NCPkgPackageDetails.cc
@@ -62,8 +62,8 @@ std::string NCPkgPackageDetails::createRelLine( const zypp::Capabilities & info 
 {
     std::string text = "";
     zypp::Capabilities::const_iterator
-	b = info.begin (),
-	e = info.end (),
+	b = info.begin(),
+	e = info.end(),
 	it;
     unsigned int i, n = info.size();
 
@@ -131,7 +131,7 @@ void NCPkgPackageDetails::longDescription ( ZyppObj pkgPtr )
    if ( !pkgPtr )
        return;
 
-   //text += commonHeader( pkgPtr );
+   // text += commonHeader( pkgPtr );
    text += pkgPtr->description();
 
    // show the description
@@ -149,13 +149,13 @@ void NCPkgPackageDetails::technicalData( ZyppObj pkgPtr, ZyppSel slbPtr )
 
     text += commonHeader( pkgPtr );
 
-    if ( slbPtr->hasBothObjects () )
+    if ( slbPtr->hasBothObjects() )
     {
-        ZyppObj io = slbPtr->installedObj ();
+        ZyppObj io = slbPtr->installedObj();
         instVersion = io->edition().version();
         instVersion += "-";
         instVersion += io->edition().release();
-        ZyppObj co = slbPtr->candidateObj ();
+        ZyppObj co = slbPtr->candidateObj();
         version = co->edition().version();
         version += "-";
         version += co->edition().release();
@@ -196,7 +196,7 @@ void NCPkgPackageDetails::technicalData( ZyppObj pkgPtr, ZyppSel slbPtr )
         // add the media nr
         text += NCPkgStrings::MediaNo();
         char num[5];
-        int medianr = package->mediaNr ();
+        int medianr = package->mediaNr();
         sprintf( num, "%d", medianr );
         text += num;
         text += "<br>";
@@ -209,7 +209,7 @@ void NCPkgPackageDetails::technicalData( ZyppObj pkgPtr, ZyppSel slbPtr )
 
         // the rpm group
         text += NCPkgStrings::RpmGroup();
-        text += package->group ();
+        text += package->group();
         text += "<br>";
 
 	// name of the source package
@@ -224,7 +224,7 @@ void NCPkgPackageDetails::technicalData( ZyppObj pkgPtr, ZyppSel slbPtr )
         {
             std::string author_text;
             text += NCPkgStrings::Authors();
-            //authors, in one line
+            // authors, in one line
             author_text = createText( authors, true );
             // escape html
             boost::replace_all( author_text, "<", "&lt;" );
@@ -250,7 +250,7 @@ void NCPkgPackageDetails::fileList( ZyppSel slbPtr )
        // get the file list from the package manager/show the list
        zypp::Package::FileList pkgfilelist( package->filelist() );
        std::list<std::string> fileList( pkgfilelist.begin(), pkgfilelist.end() );
-       text += createText( fileList, false ) ;
+       text += createText( fileList, false );
    }
 
    else
@@ -279,10 +279,10 @@ void NCPkgPackageDetails::dependencyList( ZyppObj pkgPtr, ZyppSel slbPtr )
         zypp::Dep deptype = deptypes[i];
         zypp::Capabilities relations = pkgPtr->dep (deptype);
         std::string relline = createRelLine (relations);
-        if (!relline.empty ())
+        if (!relline.empty())
         {
     	// FIXME: translate
-    	text += "<b>" + deptype.asString () + ": </b>"
+    	text += "<b>" + deptype.asString() + ": </b>"
     	    + relline + "<br>";
         }
     }
@@ -330,8 +330,8 @@ std::string NCPkgPackageDetails::createHtmlText( std::string value )
                 html_descr.append( NCstring("</p><p>") );
             }
         }
-        else if ( curr_line.Str().substr(0,2) == "- "
-                  || curr_line.Str().substr(0,2) == "* ")         // list item found
+        else if ( curr_line.Str().substr(0, 2) == "- "
+                  || curr_line.Str().substr(0, 2) == "* ")         // list item found
         {
             ul_found = true;
             if ( !ul_begin )
@@ -345,7 +345,7 @@ std::string NCPkgPackageDetails::createHtmlText( std::string value )
             }
             html_descr.append( NCstring(curr_line.Str().substr(2)) );
         }
-        else if ( curr_line.Str().substr(0,2) == "  " )      // white spaces at begin
+        else if ( curr_line.Str().substr(0, 2) == "  " )      // white spaces at begin
         {
             // just append the line (is added to list item or to paragraph)
             html_descr.append( NCstring( curr_line.Str() ) );

--- a/src/NCPkgPackageDetails.h
+++ b/src/NCPkgPackageDetails.h
@@ -38,7 +38,7 @@
 /-*/
 
 #ifndef NCPkgPackageDetails_h
-#define NCPkgPackageDetails_h 
+#define NCPkgPackageDetails_h
 
 #include "NCRichText.h"
 #include "NCZypp.h"
@@ -46,9 +46,8 @@
 class NCPackageSelector;
 
 
-class NCPkgPackageDetails : public NCRichText {
-
-
+class NCPkgPackageDetails : public NCRichText
+{
     NCPkgPackageDetails & operator=( const NCPkgPackageDetails & );
     NCPkgPackageDetails            ( const NCPkgPackageDetails & );
 
@@ -62,7 +61,7 @@ public:
     std::string createText( std::list <std::string> info, bool oneline );
 
     std::string createHtmlText( std::string description );
-    
+
     std::string createRelLine( const zypp::Capabilities & info );
 
     std::string commonHeader( ZyppObj pkgPtr );
@@ -73,7 +72,7 @@ public:
 
     void fileList (ZyppSel slbPtr);
 
-    void dependencyList( ZyppObj objPtr, ZyppSel slbPtr );    
+    void dependencyList( ZyppObj objPtr, ZyppSel slbPtr );
 
     bool patchDescription( ZyppObj objPtr, ZyppSel selectable );
 };

--- a/src/NCPkgPatchSearch.cc
+++ b/src/NCPkgPatchSearch.cc
@@ -152,10 +152,11 @@ void NCPkgPatchSearch::createLayout( const std::string & headline )
 //
 //	DESCRIPTION :
 //
-NCursesEvent & NCPkgPatchSearch::showSearchPopup( )
+NCursesEvent & NCPkgPatchSearch::showSearchPopup()
 {
     postevent = NCursesEvent();
-    do {
+    do
+    {
 	popupDialog();
 	if ( searchExpr )
 	{

--- a/src/NCPkgPatchSearch.h
+++ b/src/NCPkgPatchSearch.h
@@ -61,8 +61,8 @@ class NCPackageSelector;
 //
 //	DESCRIPTION :
 //
-class NCPkgPatchSearch : public NCPopup {
-
+class NCPkgPatchSearch : public NCPopup
+{
     NCPkgPatchSearch & operator=( const NCPkgPatchSearch & );
     NCPkgPatchSearch            ( const NCPkgPatchSearch & );
 
@@ -96,7 +96,7 @@ public:
 
     void createLayout( const std::string & headline );
 
-    NCursesEvent & showSearchPopup( );
+    NCursesEvent & showSearchPopup();
 
 };
 

--- a/src/NCPkgPopupDeps.cc
+++ b/src/NCPkgPopupDeps.cc
@@ -79,9 +79,10 @@ public:
     NCProblemSelectionBox (YWidget * parent, const std::string & label,
 			   NCPkgPopupDeps * aDepsPopup)
 	: NCSelectionBox( parent, label),
-	  depsPopup (aDepsPopup) {}
+	  depsPopup( aDepsPopup )
+        {}
 
-    virtual ~NCProblemSelectionBox () {}
+    virtual ~NCProblemSelectionBox() {}
 };
 
 class NCSolutionSelectionBox : public NCMultiSelectionBox
@@ -100,10 +101,15 @@ public:
     NCSolutionSelectionBox (YWidget * parent, const std::string & label,
 			    NCPkgPopupDeps * aDepsPopup)
 	: NCMultiSelectionBox( parent, label)
-	, depsPopup (aDepsPopup) {}
+	, depsPopup( aDepsPopup )
+        {}
 
-    virtual ~NCSolutionSelectionBox () {}
-    void saveDetails( YItem * item, std::string details ) { detailsMap[item] = details; }
+    virtual ~NCSolutionSelectionBox() {}
+
+    void saveDetails( YItem * item, std::string details )
+    {
+        detailsMap[item] = details;
+    }
 };
 
 
@@ -150,7 +156,7 @@ NCPkgPopupDeps::~NCPkgPopupDeps()
 //
 //	DESCRIPTION :
 //
-void NCPkgPopupDeps::createLayout( )
+void NCPkgPopupDeps::createLayout()
 {
 
   // vertical split is the (only) child of the dialog
@@ -280,7 +286,7 @@ bool NCPkgPopupDeps::solve( NCSelectionBox * problemw, NCPkgSolverAction action 
 	    success = resolver->resolvePool();
 	    break;
 	case S_Verify:
-	    success = resolver->verifySystem( ); // check hardware
+	    success = resolver->verifySystem(); // check hardware
 	    break;
 	default:
 	    yuiError() << "Unknown action for resolve" << endl;
@@ -294,23 +300,23 @@ bool NCPkgPopupDeps::solve( NCSelectionBox * problemw, NCPkgSolverAction action 
 	return true;
 
     // clear list
-    problems.clear ();
-    problemw->deleteAllItems ();
+    problems.clear();
+    problemw->deleteAllItems();
 
-    zypp::ResolverProblemList rproblems = resolver->problems ();
+    zypp::ResolverProblemList rproblems = resolver->problems();
     zypp::ResolverProblemList::iterator
-	b = rproblems.begin (),
-	e = rproblems.end (),
+	b = rproblems.begin(),
+	e = rproblems.end(),
 	i;
     int idx;
 
     for (i = b, idx = 0; i != e; ++i, ++idx)
     {
-	yuiMilestone() << "Problem: " << (*i)->description () << endl;
-	yuiMilestone() << "Details: " << (*i)->details () << endl;
+	yuiMilestone() << "Problem: " << (*i)->description() << endl;
+	yuiMilestone() << "Details: " << (*i)->details() << endl;
 
 	// no solution yet
-	problems.push_back (std::make_pair (*i, zypp::ProblemSolution_Ptr ()));
+	problems.push_back (std::make_pair (*i, zypp::ProblemSolution_Ptr()));
 
 	problemw->addItem( (*i)->description(), false );	// selected: false
     }
@@ -323,7 +329,7 @@ bool NCPkgPopupDeps::showSolutions( int index )
     if (!solutionw)
 	return false;
 
-    unsigned int size = problems.size ();
+    unsigned int size = problems.size();
 
     if ( index < 0 || (unsigned int)index >= size )
 	return false;
@@ -336,18 +342,19 @@ bool NCPkgPopupDeps::showSolutions( int index )
 
     details->setText( problem->details() );
 
-    zypp::ProblemSolutionList solutions = problem->solutions ();
+    zypp::ProblemSolutionList solutions = problem->solutions();
     zypp::ProblemSolutionList::iterator
-	bb = solutions.begin (),
-	ee = solutions.end (),
+	bb = solutions.begin(),
+	ee = solutions.end(),
 	ii;
 
     bool showDetails = true;;
     std::string description;
 
-    for (ii = bb; ii != ee; ++ii) {
-	yuiMilestone() << "Solution:  " << (*ii)->description () << endl;
-	yuiMilestone() << "Details:   " << (*ii)->details () << endl;
+    for ( ii = bb; ii != ee; ++ii)
+    {
+	yuiMilestone() << "Solution:  " << (*ii)->description() << endl;
+	yuiMilestone() << "Details:   " << (*ii)->details() << endl;
 	yuiMilestone() << "User decision: " << user_solution << endl;
 
 	description = (*ii)->description();
@@ -389,7 +396,8 @@ NCursesEvent NCPkgPopupDeps::showDependencyPopup( NCPkgSolverAction action )
 {
     postevent = NCursesEvent();
 
-    do {
+    do
+    {
 	popupDialog();
     } while ( postAgain( action ) );
 
@@ -463,8 +471,8 @@ bool NCPkgPopupDeps::postAgain( NCPkgSolverAction action )
 	// apply the solution here
 	zypp::Resolver_Ptr resolver = zypp::getZYpp()->resolver();
 	ProblemSolutionCorrespondence::iterator
-	    b = problems.begin (),
-	    e = problems.end (),
+	    b = problems.begin(),
+	    e = problems.end(),
 	    i;
 	zypp::ProblemSolutionList solutions;
 	for (i = b; i != e; ++i)
@@ -514,19 +522,22 @@ void NCPkgPopupDeps::setSolution (int index)
 {
     // we must search the list :( bad design here
     // but the solution list is short
-    int prob_num = problemw->getCurrentItem ();
+    int prob_num = problemw->getCurrentItem();
     zypp::ResolverProblem_Ptr problem = problems[prob_num].first;
-    zypp::ProblemSolution_Ptr sol = zypp::ProblemSolution_Ptr ();
+    zypp::ProblemSolution_Ptr sol = zypp::ProblemSolution_Ptr();
 
-    zypp::ProblemSolutionList solutions = problem->solutions ();
+    zypp::ProblemSolutionList solutions = problem->solutions();
     zypp::ProblemSolutionList::iterator
-	bb = solutions.begin (),
-	ee = solutions.end (),
+	bb = solutions.begin(),
+	ee = solutions.end(),
 	ii;
     int idx;
-    for (ii = bb, idx = 0; ii != ee && idx < index; ++ii, ++idx) {
-	//empty
+
+    for (ii = bb, idx = 0; ii != ee && idx < index; ++ii, ++idx)
+    {
+	// empty
     }
+
     if (ii != ee)
 	sol = *ii;
 
@@ -570,17 +581,14 @@ NCursesEvent NCProblemSelectionBox::wHandleInput( wint_t key )
 	case KEY_NPAGE:
 	case KEY_PPAGE:
 	case KEY_END:
-	case KEY_HOME: {
+	case KEY_HOME:
 	    // show the corresponding information
-	    depsPopup->showSolutions (getCurrentItem ());
+	    depsPopup->showSolutions (getCurrentItem());
 	    ret = NCursesEvent::handled;
 	    break;
-	}
-	default: {
-//?
-//	    ret = NCursesEvent::handled;
+
+	default:
 	    break;
-	}
     }
 
     return ret;
@@ -601,29 +609,29 @@ NCursesEvent NCSolutionSelectionBox::wHandleInput( wint_t key )
     switch ( key )
     {
 	case KEY_SPACE:
-	case KEY_RETURN: {
+	case KEY_RETURN:
+        {
 	    // act like a radio button
 	    // make sure that only one item is selected
-	    YItem *cur = currentItem ();
+	    YItem *cur = currentItem();
 	    bool on = isItemSelected( cur );
 	    if (on)
 	    {
-		deselectAllItems ();
+		deselectAllItems();
 		selectItem (cur, true);
 		depsPopup->setSolution ( cur->index() );
 	    }
 	    break;
 	}
+
 	case KEY_UP:
-	case KEY_DOWN: {
+	case KEY_DOWN:
 	    // show details
 	    depsPopup->showSolutionDetails( detailsMap[currentItem()] );
 	    break;
-	}
 
-	default: {
+	default:
 	    break;
-	}
     }
 
     return ret;

--- a/src/NCPkgPopupDeps.h
+++ b/src/NCPkgPopupDeps.h
@@ -60,7 +60,8 @@ class NCPackageSelector;
 class NCRichText;
 class NCSolutionSelectionBox;
 
-namespace PkgDep {
+namespace PkgDep
+{
     class ErrorResult;
     class ErrorResultList;
     class ResultList;
@@ -72,18 +73,19 @@ namespace PkgDep {
 //
 //	DESCRIPTION :
 //
-class NCPkgPopupDeps : public NCPopup {
-
+class NCPkgPopupDeps : public NCPopup
+{
     NCPkgPopupDeps & operator=( const NCPkgPopupDeps & );
     NCPkgPopupDeps            ( const NCPkgPopupDeps & );
 
 public:
-    enum NCPkgSolverAction {
+    enum NCPkgSolverAction
+    {
 	S_Solve,
 	S_Verify,
 	S_Unknown
     };
-    
+
 private:
 
     typedef std::vector<std::pair<
@@ -94,27 +96,27 @@ private:
     ProblemSolutionCorrespondence problems;
 
     NCPushButton * cancelButton;
-    NCPushButton * solveButton;		
-    
+    NCPushButton * solveButton;
+
     NCSolutionSelectionBox * solutionw; // resolver problem solutions
 
     NCLabel * head;			// the headline
 
     NCLabel *details;		// problem details
     NCRichText *solDetails;	// solution details
-    
+
     NCPackageSelector * packager;	// connection to the package selector
-    
+
     void createLayout();
-    
+
 protected:
 
     NCSelectionBox * problemw;	// resolver problems
-    
+
     virtual bool postAgain( NCPkgSolverAction action );
 
     virtual NCursesEvent wHandleInput( wint_t ch );
-    
+
 public:
 
     NCPkgPopupDeps( const wpos at, NCPackageSelector * pkger );
@@ -126,7 +128,7 @@ public:
     NCursesEvent showDependencyPopup( NCPkgSolverAction action );
 
     bool showDependencies( NCPkgSolverAction action, bool * ok );
-    
+
     bool solve( NCSelectionBox * problemw,  NCPkgSolverAction action );
 
     bool showSolutions( int index );

--- a/src/NCPkgPopupDescr.cc
+++ b/src/NCPkgPopupDescr.cc
@@ -77,7 +77,7 @@ NCPkgPopupDescr::NCPkgPopupDescr( const wpos at, NCPackageSelector * pkger )
       , headline( 0 )
       , packager( pkger )
 {
-    createLayout( );
+    createLayout();
 }
 
 ///////////////////////////////////////////////////////////////////
@@ -100,7 +100,7 @@ NCPkgPopupDescr::~NCPkgPopupDescr()
 //
 //	DESCRIPTION :
 //
-void NCPkgPopupDescr::createLayout( )
+void NCPkgPopupDescr::createLayout()
 {
     // the vertical split is the (only) child of the dialog
     NCLayoutBox * split = new NCLayoutBox( this, YD_VERT );
@@ -174,9 +174,10 @@ NCursesEvent NCPkgPopupDescr::showInfoPopup( ZyppPkg pkgPtr, ZyppSel slbPtr )
 
     fillData( pkgPtr, slbPtr );
 
-    do {
+    do
+    {
 	// show the popup
-	popupDialog( );
+	popupDialog();
     } while ( postAgain() );
 
     popdownDialog();
@@ -230,7 +231,7 @@ NCursesEvent NCPkgPopupDescr::wHandleInput( wint_t ch )
 //	METHOD TYPE : bool
 //
 //	DESCRIPTION :
-//x
+// x
 bool NCPkgPopupDescr::postAgain()
 {
     if ( ! postevent.widget )

--- a/src/NCPkgPopupDescr.h
+++ b/src/NCPkgPopupDescr.h
@@ -59,8 +59,8 @@ class NCRichText;
 //
 //	DESCRIPTION :
 //
-class NCPkgPopupDescr : public NCPopup {
-
+class NCPkgPopupDescr : public NCPopup
+{
     NCPkgPopupDescr & operator=( const NCPkgPopupDescr & );
     NCPkgPopupDescr            ( const NCPkgPopupDescr & );
 
@@ -70,7 +70,7 @@ private:
     NCPushButton * okButton;
     NCRichText *descrText;
     NCLabel *headline;
-    
+
     NCPackageSelector * packager;
 
 protected:
@@ -78,18 +78,18 @@ protected:
     virtual bool postAgain();
 
     virtual NCursesEvent wHandleInput( wint_t ch );
-    
+
 public:
-    
+
     NCPkgPopupDescr( const wpos at, NCPackageSelector * pkger );
-    
+
     virtual ~NCPkgPopupDescr();
 
     virtual long nicesize(YUIDimension dim);
 
     bool fillData( ZyppPkg pkgPtr, ZyppSel slbPtr );
 
-    void createLayout( );
+    void createLayout();
 
     NCursesEvent showInfoPopup( ZyppPkg pkgPtr, ZyppSel slbPtr );
 

--- a/src/NCPkgPopupDiskspace.cc
+++ b/src/NCPkgPopupDiskspace.cc
@@ -128,7 +128,7 @@ namespace
         int width = 0;
         for (const ZyppPartitionDu &du: get_du())
         {
-            if( int(du.dir.length()) > width )
+            if ( int(du.dir.length()) > width )
                 width = du.dir.length();
         }
         yuiDebug() << "The longest mount point path: " << width << " characters" << endl;
@@ -172,7 +172,7 @@ NCPkgDiskspace::NCPkgDiskspace( bool testMode )
     if ( testMode )
     {
 	yuiMilestone() << "TESTMODE Diskspace" << endl;
-	zypp::getZYpp()->setPartitions(zypp::DiskUsageCounter::detectMountPoints ());
+	zypp::getZYpp()->setPartitions(zypp::DiskUsageCounter::detectMountPoints());
 	testDiskUsage = zypp::getZYpp()->diskUsage();
     }
 }
@@ -363,7 +363,7 @@ void NCPkgDiskspace::setDiskSpace( wint_t ch )
 //
 //	DESCRIPTION : calls checkRemaingDiskspace for every partition
 //
-void NCPkgDiskspace::checkDiskSpaceRange( )
+void NCPkgDiskspace::checkDiskSpaceRange()
 {
     // see YQPkgDiskUsageList::updateDiskUsage()
     runningOutWarning.clear();
@@ -377,8 +377,8 @@ void NCPkgDiskspace::checkDiskSpaceRange( )
 
     for (const ZyppPartitionDu &du: diskUsage)
     {
-	//Exclude readonly dirs from the check (#384368)
-	if( du.readonly )
+	// Exclude readonly dirs from the check (#384368)
+	if ( du.readonly )
 	    continue;
 	checkRemainingDiskSpace( du );
     }
@@ -539,9 +539,10 @@ int NCPkgPopupDiskspace::preferredHeight()
 void NCPkgPopupDiskspace::doit()
 {
     postevent = NCursesEvent();
-    do {
+    do
+    {
 	// show the popup
-	popupDialog( );
+	popupDialog();
     } while ( postAgain() );
 
     popdownDialog();

--- a/src/NCPkgPopupDiskspace.h
+++ b/src/NCPkgPopupDiskspace.h
@@ -136,7 +136,7 @@ public:
 
     /*
      * Log settings to y2log
-     */ 
+     */
     void logSettings() const;
 
     /**
@@ -159,8 +159,8 @@ protected:
     bool 	_warningPosted;
 };
 
-class NCPkgPopupDiskspace : public NCPopup {
-
+class NCPkgPopupDiskspace : public NCPopup
+{
 private:
     NCTable * partitions;
     NCPushButton * okButton;
@@ -171,7 +171,7 @@ protected:
     virtual bool postAgain();
 
     virtual NCursesEvent wHandleInput( wint_t ch );
-  
+
 public:
     NCPkgPopupDiskspace( const wpos at, std::string headline );
 
@@ -193,8 +193,8 @@ public:
 //
 //	DESCRIPTION :
 //
-class NCPkgDiskspace {
-
+class NCPkgDiskspace
+{
     NCPkgDiskspace & operator=( const NCPkgDiskspace & );
     NCPkgDiskspace            ( const NCPkgDiskspace & );
 
@@ -215,25 +215,25 @@ private:
      * Warning range notifier about disk space overflow warning.
      **/
     NCPkgWarningRangeNotifier overflowWarning;
-    
-  
+
+
 public:
-    
+
     NCPkgDiskspace(  bool testSpaceMode );
-    
+
     virtual ~NCPkgDiskspace();
 
-    
+
     void fillPartitionTable();
 
     std::string checkDiskSpace();
 
     void setDiskSpace( wint_t key );	// used for testing
-    
-    void checkDiskSpaceRange( );
-    
+
+    void checkDiskSpaceRange();
+
     void showInfoPopup( std::string headline );
- 
+
     void checkRemainingDiskSpace( const ZyppPartitionDu & partition );
 
     FSize calculateDiff();

--- a/src/NCPkgPopupTable.cc
+++ b/src/NCPkgPopupTable.cc
@@ -178,20 +178,20 @@ bool NCPkgPopupTable::fillAutoChanges( NCPkgTable * pkgTable )
 
     std::set<std::string> ignoredNames;
     std::set<std::string> userWantedNames = zypp::ui::userWantedPackageNames();
-    //these are the packages already selected for autoinstallation in previous 'verify system' run
+    // these are the packages already selected for autoinstallation in previous 'verify system' run
     std::set<std::string> verifiedNames = packager->getVerifiedPkgs();
 
-    //initialize storage for the new set
+    // initialize storage for the new set
     std::insert_iterator< std::set<std::string> > result (ignoredNames, ignoredNames.begin());
 
-    if(!verifiedNames.empty())
+    if (!verifiedNames.empty())
     {
-	//if we have some leftovers from previous run, do the union of the sets
+	// if we have some leftovers from previous run, do the union of the sets
 	set_union(userWantedNames.begin(), userWantedNames.end(),
 	           verifiedNames.begin(), verifiedNames.end(), result );
     }
     else
-	//else just take userWanted stuff
+	// else just take userWanted stuff
 	ignoredNames = userWantedNames;
 
     for ( std::set<std::string>::iterator it = ignoredNames.begin(); it != ignoredNames.end(); ++it )
@@ -207,7 +207,7 @@ bool NCPkgPopupTable::fillAutoChanges( NCPkgTable * pkgTable )
 	ZyppSel slb = *it;
 
 	// show all packages which are automatically selected for installation
-	if ( slb->toModify() && slb->modifiedBy () != zypp::ResStatus::USER )
+	if ( slb->toModify() && slb->modifiedBy() != zypp::ResStatus::USER )
 	{
 	    if ( ! inContainer( ignoredNames, slb->name() ) )
 	    {
@@ -216,7 +216,7 @@ bool NCPkgPopupTable::fillAutoChanges( NCPkgTable * pkgTable )
 		{
 		    yuiMilestone() << "The status of " << pkgPtr->name() << " has automatically changed" << endl;
 		    pkgTable->createListEntry( pkgPtr, slb );
-		    //also add to 'already verified' set
+		    // also add to 'already verified' set
 		    packager->insertVerifiedPkg( pkgPtr->name() );
 		}
 	    }
@@ -257,7 +257,7 @@ bool NCPkgPopupTable::fillAvailables( NCPkgTable * pkgTable, ZyppSel sel )
 //
 //	DESCRIPTION :
 //
-NCursesEvent NCPkgPopupTable::showInfoPopup( )
+NCursesEvent NCPkgPopupTable::showInfoPopup()
 {
     postevent = NCursesEvent();
 
@@ -267,9 +267,10 @@ NCursesEvent NCPkgPopupTable::showInfoPopup( )
 	return postevent;
     }
 
-    do {
+    do
+    {
 	// show the popup
-	popupDialog( );
+	popupDialog();
     } while ( postAgain() );
 
     popdownDialog();
@@ -287,9 +288,10 @@ NCursesEvent NCPkgPopupTable::showAvailablesPopup( ZyppSel sel )
 	return postevent;
     }
 
-    do {
+    do
+    {
 	// show the popup
-	popupDialog( );
+	popupDialog();
     } while ( postAgain() );
 
     popdownDialog();
@@ -353,7 +355,7 @@ bool NCPkgPopupTable::postAgain()
 
     if ( postevent.widget == cancelButton )
     {
-	//user hit cancel - discard set of changes (if not empty)
+	// user hit cancel - discard set of changes (if not empty)
 	packager->clearVerifiedPkgs();
 
 	// close the dialog

--- a/src/NCPkgPopupTable.h
+++ b/src/NCPkgPopupTable.h
@@ -61,8 +61,8 @@ class NCPackageSelector;
 //
 //	DESCRIPTION :
 //
-class NCPkgPopupTable : public NCPopup {
-
+class NCPkgPopupTable : public NCPopup
+{
     NCPkgPopupTable & operator=( const NCPkgPopupTable & );
     NCPkgPopupTable            ( const NCPkgPopupTable & );
 
@@ -78,20 +78,20 @@ protected:
     virtual bool postAgain();
 
     virtual NCursesEvent wHandleInput( wint_t ch );
-    
+
 public:
-    
+
     NCPkgPopupTable( const wpos at, NCPackageSelector * pkger,
                      std::string headline,
                      std::string label1,
                      std::string label2,
                      bool add_cancel = true );
-    
+
     virtual ~NCPkgPopupTable();
 
     virtual int preferredWidth();
     virtual int preferredHeight();
-    
+
     bool fillAutoChanges( NCPkgTable * pkgTable );
 
     bool fillAvailables( NCPkgTable * pkgTable, ZyppSel sel );
@@ -101,7 +101,7 @@ public:
                        std::string label2,
                        bool add_cancel );
 
-    NCursesEvent showInfoPopup( );
+    NCursesEvent showInfoPopup();
     NCursesEvent showAvailablesPopup( ZyppSel sel );
 
 };

--- a/src/NCPkgSearchSettings.cc
+++ b/src/NCPkgSearchSettings.cc
@@ -60,17 +60,17 @@ NCPkgSearchSettings::~NCPkgSearchSettings()
 void NCPkgSearchSettings::createLayout()
 {
    checkName = new YItem ( _( "Name of the Package" ), true);
-   items.push_back (checkName); 
+   items.push_back (checkName);
    checkSummary = new YItem ( _( "Summary" ), true);
-   items.push_back (checkSummary); 
+   items.push_back (checkSummary);
    checkKeywords = new YItem ( _( "Keywords" ));
-   items.push_back (checkKeywords); 
+   items.push_back (checkKeywords);
    checkDescr = new YItem ( _( "Description (time-consuming)" ));
-   items.push_back (checkDescr); 
+   items.push_back (checkDescr);
    checkProvides = new YItem ( _( "Provides" ));
-   items.push_back (checkProvides); 
+   items.push_back (checkProvides);
    checkRequires = new YItem ( _( "Required by" ));
-   items.push_back (checkRequires); 
+   items.push_back (checkRequires);
 
    addItems( items );
 }
@@ -78,25 +78,25 @@ void NCPkgSearchSettings::createLayout()
 bool NCPkgSearchSettings::doCheckName()
 {
     return checkName->selected();
-} 
+}
 bool NCPkgSearchSettings::doCheckSummary()
 {
     return checkSummary->selected();
-} 
+}
 bool NCPkgSearchSettings::doCheckKeywords()
 {
     return checkKeywords->selected();
-} 
+}
 bool NCPkgSearchSettings::doCheckDescr()
 {
     return checkDescr->selected();
-} 
+}
 bool NCPkgSearchSettings::doCheckProvides()
 {
     return checkProvides->selected();
-} 
+}
 bool NCPkgSearchSettings::doCheckRequires()
 {
     return checkRequires->selected();
-} 
+}
 

--- a/src/NCPkgSearchSettings.h
+++ b/src/NCPkgSearchSettings.h
@@ -48,8 +48,8 @@
 #include "NCi18n.h"
 #include "NCMultiSelectionBox.h"
 
-class NCPkgSearchSettings : public NCMultiSelectionBox {
-
+class NCPkgSearchSettings : public NCMultiSelectionBox
+{
     NCPkgSearchSettings & operator=( const NCPkgSearchSettings & );
     NCPkgSearchSettings             ( const NCPkgSearchSettings & );
 
@@ -61,11 +61,11 @@ public:
     YItem *checkKeywords;
     YItem *checkDescr;
     YItem *checkProvides;
-    YItem *checkRequires; 
+    YItem *checkRequires;
 
 
    NCPkgSearchSettings (YWidget *parent, std::string label);
-   virtual ~NCPkgSearchSettings();   
+   virtual ~NCPkgSearchSettings();
 
    void createLayout();
 

--- a/src/NCPkgSelMapper.h
+++ b/src/NCPkgSelMapper.h
@@ -86,7 +86,7 @@ public:
     /**
      * Rebuild the shared cache. This is expensive. Call this only when the
      * ZyppPool has changed, i.e. after installation sources were added or
-     * removed. 
+     * removed.
      *
      * Since the cache is shared, this affects all instances of this class.
      **/

--- a/src/NCPkgStatusStrategy.cc
+++ b/src/NCPkgStatusStrategy.cc
@@ -184,8 +184,8 @@ bool NCPkgStatusStrategy::keyToStatus( const int & key,
 		valid = false;
 	    }
 	    break;
-	//this is the case for 'going back' i.e. S_Install -> S_NoInst, S_Update -> S_KeepInstalled
-	//not for S_Del, since '+' key does this
+	// this is the case for 'going back' i.e. S_Install -> S_NoInst, S_Update -> S_KeepInstalled
+	// not for S_Del, since '+' key does this
 	case '<':
 	    if ( oldStatus == S_Install
 		 || oldStatus == S_AutoInstall )
@@ -247,7 +247,7 @@ bool NCPkgStatusStrategy::toggleStatus( ZyppSel slbPtr,
 	    newStatus = S_KeepInstalled;
 	    break;
 	case S_Install:
-	    newStatus =S_NoInst ;
+	    newStatus =S_NoInst;
 	    break;
 	case S_Update:
 	    newStatus = S_Del;
@@ -451,13 +451,13 @@ bool PatchStatStrategy::toggleStatus( ZyppSel slbPtr,
     {
 	case S_Install:
 	case S_AutoInstall:
-	    newStatus = S_NoInst ;
+	    newStatus = S_NoInst;
 	    break;
 	case S_KeepInstalled:
             newStatus = S_Install;
 	    break;
 	case S_NoInst:
-	    newStatus = S_Install ;
+	    newStatus = S_Install;
 	    break;
     	case S_Taboo:
             if ( isBroken )
@@ -793,7 +793,7 @@ bool MultiVersionStatStrategy::mixedMultiVersionPopup( bool multiversion ) const
 					       );
     cancelMsg->setPreferredSize( 60, 15 );
     cancelMsg->focusCancelButton();
-    NCursesEvent input = cancelMsg->showInfoPopup( );
+    NCursesEvent input = cancelMsg->showInfoPopup();
 
     YDialog::deleteTopmostDialog();
 

--- a/src/NCPkgStatusStrategy.h
+++ b/src/NCPkgStatusStrategy.h
@@ -54,7 +54,7 @@ class NCPkgStatusStrategy
 
 public:
 
-    NCPkgStatusStrategy( );
+    NCPkgStatusStrategy();
 
     virtual ~NCPkgStatusStrategy() = 0;
 
@@ -114,7 +114,7 @@ class PackageStatStrategy : public NCPkgStatusStrategy
 {
 public:
 
-    PackageStatStrategy( );
+    PackageStatStrategy();
 
     virtual ~PackageStatStrategy() {}
 
@@ -127,7 +127,7 @@ class DependencyStatStrategy : public NCPkgStatusStrategy
 {
 public:
 
-    DependencyStatStrategy( );
+    DependencyStatStrategy();
 
     virtual ~DependencyStatStrategy() {}
 
@@ -140,7 +140,7 @@ class UpdateStatStrategy : public NCPkgStatusStrategy
 {
 public:
 
-    UpdateStatStrategy( );
+    UpdateStatStrategy();
 
     virtual ~UpdateStatStrategy() {}
 
@@ -153,7 +153,7 @@ class SelectionStatStrategy : public NCPkgStatusStrategy
 {
 public:
 
-    SelectionStatStrategy( );
+    SelectionStatStrategy();
 
     virtual ~SelectionStatStrategy() {}
 
@@ -177,7 +177,7 @@ class PatchPkgStatStrategy : public NCPkgStatusStrategy
 {
 public:
 
-    PatchPkgStatStrategy( );
+    PatchPkgStatStrategy();
 
     virtual ~PatchPkgStatStrategy() {}
 
@@ -200,7 +200,7 @@ class PatchStatStrategy : public NCPkgStatusStrategy
 {
 public:
 
-    PatchStatStrategy( );
+    PatchStatStrategy();
 
     virtual ~PatchStatStrategy() {}
 
@@ -244,7 +244,7 @@ class AvailableStatStrategy : public NCPkgStatusStrategy
 {
 public:
 
-    AvailableStatStrategy( );
+    AvailableStatStrategy();
 
     virtual ~AvailableStatStrategy() {}
 
@@ -268,7 +268,7 @@ class MultiVersionStatStrategy : public NCPkgStatusStrategy
 {
 public:
 
-    MultiVersionStatStrategy( );
+    MultiVersionStatStrategy();
 
     virtual ~MultiVersionStatStrategy() {}
 

--- a/src/NCPkgStrings.cc
+++ b/src/NCPkgStrings.cc
@@ -860,3 +860,12 @@ const std::string NCPkgStrings::NotMultiversionText()
     return value;
 }
 
+const std::string NCPkgStrings::RetractedLabel()
+{
+    // Special status for versions of a package that are retracted, i.e. that
+    // were released, but it was later realized that a broken version was
+    // published that should rather not be used. This is a very exceptional
+    // case that requires special attention by the user.
+    static const std::string value = _( "[RETRACTED]" );
+    return value;
+}

--- a/src/NCPkgStrings.cc
+++ b/src/NCPkgStrings.cc
@@ -53,28 +53,28 @@
 
 const std::string NCPkgStrings::Deps()
 {
-    //menu entry 1 - all about pkg dependencies
+    // menu entry 1 - all about pkg dependencies
     static const std::string value = _( "&Dependencies" );
     return value;
 }
 
 const std::string NCPkgStrings::View()
 {
-    //menu entry 2 - display different kinds of info on pkgs
+    // menu entry 2 - display different kinds of info on pkgs
     static const std::string value = _( "&View" );
     return value;
 }
 
 const std::string NCPkgStrings::Extras()
 {
-    //menu entry 3 - miscellaneous stuff
+    // menu entry 3 - miscellaneous stuff
     static const std::string value = _( "&Extras" );
     return value;
 }
 
 const std::string NCPkgStrings::Filter()
 {
-    //pick a package filter - patterns, langs, repos, search,...
+    // pick a package filter - patterns, langs, repos, search,...
     static const std::string value = _( "&Filter" );
     return value;
 }
@@ -137,11 +137,11 @@ const std::string NCPkgStrings::HelpPkgGen3()
     return value;
 }
 
-const std::string NCPkgStrings::HelpPkgGen4 ()
+const std::string NCPkgStrings::HelpPkgGen4()
 {
     // part2 of help text package installation
     static const std::string value =  _( "<ol><li>Package status (for more information see <i>Package Status and Symbols</i>)</li> <li>Package name</li><li>Package summary</li><li>Available version (in some of the configured repositories)</li> <li>Installed version(empty for not yet installed packages)</li> <li>Package size</li></ol>" );
-    
+
     return value;
 }
 
@@ -279,7 +279,7 @@ const std::string NCPkgStrings::HelpPkgMenu2_3()
     static const std::string value =  _("<p>Advanced options:<br> <i>Cleanup when deleting packages</i>: remove dependent unused packages. <i>Allow vendor change</i>: package vendor may differ from vendor of installed package. These options will not be saved, they can only be set in the configuration file of the package library <tt>/etc/zypp/zypp.conf</tt>.</p>" );
     return value;
 }
-                                   
+
 const std::string NCPkgStrings::HelpPkgMenu3()
 {
     static const std::string value =  _( "<p><b>View:</b><br>Choose which information about the selected package will be displayed in the window below the package table. Available options are: package description, technical data (version, size, license etc.) package versions (all available), file list (all files included in the package) and dependencies (provides, requires etc.).</p>" );
@@ -729,7 +729,7 @@ const std::string NCPkgStrings::CancelText()
     return value;
 }
 
-//FIXME: remove these if possible
+// FIXME: remove these if possible
 const std::string NCPkgStrings::LanguageLabel()
 {
    // the label of language table
@@ -748,8 +748,8 @@ const std::string NCPkgStrings::YOUPatches()
 {
     // A label for a list of YOU Patches - keep it short - max 25 chars!
     // (the list shows all patches which are needed)
-    //static const std::string value = _( "Installable Patches" );
-    //static const std::string value = _( "Relevant Patches" );
+    // static const std::string value = _( "Installable Patches" );
+    // static const std::string value = _( "Relevant Patches" );
     static const std::string value = _( "Needed Patches" );
     return value;
 }
@@ -759,7 +759,7 @@ const std::string NCPkgStrings::InstPatches()
     // A label for a list of YOU Patches - keep it short - max. 25 chars!
     // (the list shows all patches which are already installed)
     static const std::string value = _( "Installed Patches" );
-    //static const std::string value = _( "Satisfied Patches" );
+    // static const std::string value = _( "Satisfied Patches" );
     return value;
 }
 

--- a/src/NCPkgStrings.cc
+++ b/src/NCPkgStrings.cc
@@ -805,14 +805,6 @@ const std::string NCPkgStrings::PkgSource()
     return value;
 }
 
-#if 0
-const std::string NCPkgStrings::MenuEntryUpdateList()
-{
-    // menu entry Update List
-    static const std::string value = _( "&Update List" );
-    return value;
-}
-#endif
 const std::string NCPkgStrings::Patch()
 {
     // part of the patch description

--- a/src/NCPkgStrings.h
+++ b/src/NCPkgStrings.h
@@ -144,7 +144,7 @@ public:
     static const std::string Saving();
     static const std::string Loading();
 
-   /**
+    /**
      *  The headline of the disk space popup
      */
     static const std::string DiskspaceLabel();
@@ -154,7 +154,7 @@ public:
     static const std::string UsedSpace();
     static const std::string FreeSpace();
     static const std::string TotalSpace();
-   /**
+    /**
      * The headline of the disk space popup
      */
     static const std::string DiskSpaceError();
@@ -192,7 +192,7 @@ public:
      */
     static const std::string RpmGroup();
 
-   /**
+    /**
      * bold text Authors: (richtext)
      */
     static const std::string Authors();
@@ -219,14 +219,14 @@ public:
 
     static const std::string ListOfFiles();
     static const std::string LanguageDescription();
-   /**
+    /**
      *  text used for automatic changes popup
      */
     static const std::string AutoChangeLabel();
     static const std::string AutoChangeText1();
     static const std::string AutoChangeText2();
 
-     /**
+    /**
      * The headline of the help YOU popup
      */
     static const std::string YouHelp();
@@ -264,7 +264,7 @@ public:
      */
     static const std::string YesLabel();
 
-   /**
+    /**
      *  The label of the Accept button
      */
     static const std::string AcceptLabel();
@@ -274,7 +274,7 @@ public:
      */
     static const std::string NoLabel();
 
-     /**
+    /**
      *  The label of the Solve button
      */
     static const std::string SolveLabel();
@@ -286,19 +286,19 @@ public:
      */
     static const std::string LanguageLabel();
 
-   /**
+    /**
      *  The label of the repositories selections popup
      */
     static const std::string RepoLabel();
 
-   /**
+    /**
      *  The label Filter: YOU Patches
      */
     static const std::string YOUPatches();
     static const std::string InstPatches();
     static const std::string Patches();
 
-   /**
+    /**
      *  The label for Filter: Search results
      */
     static const std::string SearchResults();
@@ -335,6 +335,11 @@ public:
     static const std::string MultiversionIntro();
     static const std::string MultiversionText();
     static const std::string NotMultiversionText();
+
+    /**
+     * Marking for package versions that are retracted.
+     **/
+    static const std::string RetractedLabel();
 
 
 private:

--- a/src/NCPkgStrings.h
+++ b/src/NCPkgStrings.h
@@ -53,7 +53,7 @@ class NCPkgStrings
 {
 public:
 
-    // Main menu entry Dependencies     
+    // Main menu entry Dependencies
     static const std::string Deps();
 
     // Main menu entry View
@@ -61,16 +61,16 @@ public:
 
     // Main menu entry 'Extras'
     static const std::string Extras();
-    
-    //Package Filters combo box label
+
+    // Package Filters combo box label
     static const std::string Filter();
 
     static const std::string InstPkg();
 
-    //Label below the table - pkg name follows
+    // Label below the table - pkg name follows
     static const std::string PackageName();
 
-    //Actions menu (what to do with the pkg)
+    // Actions menu (what to do with the pkg)
     static const std::string Actions();
 
     static const std::string Help();
@@ -78,7 +78,7 @@ public:
     //  The headline of the help popup
     static const std::string PackageHelp();
 
-    //strings in 'General Help'
+    // strings in 'General Help'
     static const std::string HelpPkgGen1();
     static const std::string HelpPkgGen2();
     static const std::string HelpPkgGen3();
@@ -89,17 +89,17 @@ public:
     //  The headline of the help popup
     static const std::string PackageStatusHelp();
 
-    //strings in 'Package Status and symbols'
+    // strings in 'Package Status and symbols'
     static const std::string HelpOnStatus1();
     static const std::string HelpOnStatus2();
-    static const std::string HelpOnStatus3(); 
+    static const std::string HelpOnStatus3();
     static const std::string HelpOnStatus4();
     static const std::string HelpOnStatus5();
 
     //  The headline of the help popup
     static const std::string PackageFiltersHelp();
 
-    //string in 'How to use filters'
+    // string in 'How to use filters'
     static const std::string HelpOnFilters1();
     static const std::string HelpOnFilters2();
     static const std::string HelpOnFilters3();
@@ -118,11 +118,11 @@ public:
     static const std::string HelpPkgMenu4();
     static const std::string HelpPkgMenu5();
 
-    //Search settings
+    // Search settings
     static const std::string SearchIn();
     static const std::string SearchPhrase();
 
-    // table column headlines 
+    // table column headlines
     static const std::string PkgStatus();
     static const std::string PatternsLabel();
     static const std::string LangCode();
@@ -139,17 +139,17 @@ public:
     static const std::string PkgSource();
     static const std::string PatchKind();
 
-    //Useful busy popups
+    // Useful busy popups
     static const std::string Solving();
     static const std::string Saving();
     static const std::string Loading();
 
    /**
      *  The headline of the disk space popup
-     */ 
+     */
     static const std::string DiskspaceLabel();
 
-    //column headers, diskspace table
+    // column headers, diskspace table
     static const std::string Partition();
     static const std::string UsedSpace();
     static const std::string FreeSpace();
@@ -163,57 +163,57 @@ public:
     static const std::string MoreSpaceText();
 
     /**
-     * bold text Version: (richtext) 
+     * bold text Version: (richtext)
      */
     static const std::string Version();
 
     /**
-     * bold text Installed version: (richtext) 
+     * bold text Installed version: (richtext)
      */
     static const std::string InstVersion();
 
     /**
-     * bold text License: (richtext) 
+     * bold text License: (richtext)
      */
     static const std::string License();
 
     /**
-     * bold text Media No.: (richtext) 
+     * bold text Media No.: (richtext)
      */
     static const std::string MediaNo();
-    
+
     /**
-     * bold text Size: (richtext) 
+     * bold text Size: (richtext)
      */
     static const std::string Size();
 
     /**
-     * bold text Package Group: (richtext) 
+     * bold text Package Group: (richtext)
      */
     static const std::string RpmGroup();
 
    /**
-     * bold text Authors: (richtext) 
+     * bold text Authors: (richtext)
      */
     static const std::string Authors();
 
     /**
-     * bold text Provides: (richtext) 
+     * bold text Provides: (richtext)
      */
     static const std::string Provides();
 
     /**
-     * bold text Requires: (richtext) 
+     * bold text Requires: (richtext)
      */
     static const std::string Requires();
 
     /**
-     * bold text Required by: (richtext) 
+     * bold text Required by: (richtext)
      */
     static const std::string PreRequires();
 
     /**
-     * bold text Conflicts with: (richtext) 
+     * bold text Conflicts with: (richtext)
      */
     static const std::string Conflicts();
 
@@ -268,12 +268,12 @@ public:
      *  The label of the Accept button
      */
     static const std::string AcceptLabel();
-    
+
     /**
      *  The label of the No button
      */
     static const std::string NoLabel();
-    
+
      /**
      *  The label of the Solve button
      */
@@ -307,7 +307,7 @@ public:
      *  The label for Filter: Update problem
      */
     static const std::string UpdateProblem();
-    
+
     /**
      * The headline of the dependency popup
      */
@@ -316,7 +316,7 @@ public:
     static const std::string HelpOnUpdate();
 
     /**
-     * bold text Patch: (richtext) 
+     * bold text Patch: (richtext)
      */
     static const std::string Patch();
 
@@ -324,7 +324,7 @@ public:
      * Info line in empty patch list
      */
     static const std::string NoPatches();
-    
+
     static const std::string MenuList();
     static const std::string Script();
 
@@ -338,12 +338,12 @@ public:
 
 
 private:
-    
+
     // Need no object of this class: hide default constructor
     NCPkgStrings();
 
     static int do_something(){ return 0; }
-    
+
 };
 
 

--- a/src/NCPkgTable.cc
+++ b/src/NCPkgTable.cc
@@ -76,6 +76,7 @@ NCPkgTableTag::NCPkgTableTag( ZyppObj objPtr, ZyppSel selPtr, ZyppStatus stat )
     setLabel( statusToString(stat) );
 }
 
+
 std::string NCPkgTableTag::statusToString( ZyppStatus stat ) const
 {
      // convert ZyppStatus to std::string
@@ -107,6 +108,7 @@ std::string NCPkgTableTag::statusToString( ZyppStatus stat ) const
 
     return "    ";
 }
+
 
 ///////////////////////////////////////////////////////////////////
 //
@@ -171,6 +173,7 @@ void NCPkgTable::addLine( ZyppStatus stat,
 
 }
 
+
 ///////////////////////////////////////////////////////////////////
 //
 //
@@ -197,6 +200,7 @@ void NCPkgTable::cellChanged( int index, int colnum, const std::string & newtext
 {
     return NCTable::cellChanged( index, colnum, newtext );
 }
+
 
 ///////////////////////////////////////////////////////////////////
 //
@@ -360,6 +364,7 @@ bool NCPkgTable::changeStatus( ZyppStatus newstatus,
     return ok;
 }
 
+
 ///////////////////////////////////////////////////////////////////
 //
 //
@@ -430,6 +435,7 @@ bool NCPkgTable::updateTable()
     return ret;
 }
 
+
 ///////////////////////////////////////////////////////////////////
 //
 // slbHasInstalledObj
@@ -440,6 +446,7 @@ static bool slbHasInstalledObj (const ZyppSel & slb)
 {
     return ! slb->installedEmpty();
 }
+
 
 ///////////////////////////////////////////////////////////////////
 //
@@ -550,6 +557,7 @@ void NCPkgTable::fillHeader()
     }
     setHeader( header );
 }
+
 
 ///////////////////////////////////////////////////////////////////
 //
@@ -707,6 +715,7 @@ bool NCPkgTable::createListEntry ( ZyppPkg pkgPtr, ZyppSel slbPtr )
     return true;
 }
 
+
 ///////////////////////////////////////////////////////////////////
 //
 // createInfoEntry
@@ -725,6 +734,7 @@ bool NCPkgTable::createInfoEntry ( std::string text )
 
     return true;
 }
+
 
 ///////////////////////////////////////////////////////////////////
 //
@@ -764,6 +774,7 @@ bool NCPkgTable::createPatchEntry ( ZyppPatch patchPtr, ZyppSel	slb )
 
     return true;
 }
+
 
 ///////////////////////////////////////////////////////////////////
 //
@@ -865,6 +876,7 @@ NCursesEvent NCPkgTable::wHandleInput( wint_t key )
     return  NCursesEvent::handled;
 }
 
+
 ///////////////////////////////////////////////////////////////////
 //
 // NCPkgTable::getStatus()
@@ -881,6 +893,7 @@ ZyppStatus NCPkgTable::getStatus( int index )
     return cc->getStatus();
 }
 
+
 ZyppObj NCPkgTable::getDataPointer( int index )
 {
     // get the tag
@@ -891,6 +904,7 @@ ZyppObj NCPkgTable::getDataPointer( int index )
     return cc->getDataPointer();
 }
 
+
 ZyppSel NCPkgTable::getSelPointer( int index )
 {
     // get the tag
@@ -900,6 +914,7 @@ ZyppSel NCPkgTable::getSelPointer( int index )
 
     return cc->getSelPointer();
 }
+
 
 NCPkgTableTag * NCPkgTable::getTag( const int & index )
 {
@@ -915,6 +930,7 @@ NCPkgTableTag * NCPkgTable::getTag( const int & index )
 
     return cc;
 }
+
 
 #ifdef FIXME
 ///////////////////////////////////////////////////////////////////
@@ -963,6 +979,7 @@ bool NCPkgTable::SourceInstall( bool install )
 }
 #endif
 
+
 ///////////////////////////////////////////////////////////////////
 //
 // NCPkgTable::toggleObjStatus()
@@ -988,6 +1005,7 @@ bool NCPkgTable::toggleObjStatus()
     return true;
 }
 
+
 ///////////////////////////////////////////////////////////////////
 //
 // NCPkgTable::changeObjStatus()
@@ -1012,6 +1030,7 @@ bool NCPkgTable::changeObjStatus( int key )
     }
     return true;
 }
+
 
 ///////////////////////////////////////////////////////////////////
 //
@@ -1100,7 +1119,8 @@ bool NCPkgTable::changeListObjStatus( NCPkgTableListAction type )
     return true;
 }
 
-bool NCPkgTable::fillAvailableList ( ZyppSel slb )
+
+bool NCPkgTable::fillAvailableList( ZyppSel slb )
 {
     if ( !slb )
     {
@@ -1151,6 +1171,7 @@ bool NCPkgTable::fillAvailableList ( ZyppSel slb )
     return true;
 
 }
+
 
 bool NCPkgTable::fillSummaryList( NCPkgTable::NCPkgTableListType type )
 {
@@ -1206,6 +1227,7 @@ bool NCPkgTable::fillSummaryList( NCPkgTable::NCPkgTableListType type )
 
     return true;
 }
+
 
 void NCPkgTable::updateInfo( ZyppObj pkgPtr, ZyppSel slbPtr, NCPkgTableInfoType mode )
 {

--- a/src/NCPkgTable.cc
+++ b/src/NCPkgTable.cc
@@ -67,12 +67,11 @@ using std::endl;
 //
 //	DESCRIPTION :
 //
-NCPkgTableTag::NCPkgTableTag( ZyppObj objPtr, ZyppSel selPtr,
-			      ZyppStatus stat )
-      : YTableCell( "    " )
-	, status ( stat )
-	, dataPointer( objPtr )
-	, selPointer( selPtr )
+NCPkgTableTag::NCPkgTableTag( ZyppObj objPtr, ZyppSel selPtr, ZyppStatus stat )
+    : YTableCell( "    " )
+    , status ( stat )
+    , dataPointer( objPtr )
+    , selPointer( selPtr )
 {
     setLabel( statusToString(stat) );
 }
@@ -119,11 +118,11 @@ std::string NCPkgTableTag::statusToString( ZyppStatus stat ) const
 //
 NCPkgTable::NCPkgTable( YWidget * parent, YTableHeader * tableHeader )
     : NCTable( parent, tableHeader )
-      , packager ( 0 )
-      , statusStrategy( new PackageStatStrategy )	// default strategy: packages
-      , tableType ( T_Packages )			// default type: packages
-      , haveInstalledVersion ( false )
-      , visibleInfo( I_Technical )
+    , packager( 0 )
+    , statusStrategy( new PackageStatStrategy )	// default strategy: packages
+    , tableType( T_Packages )                   // default type: packages
+    , haveInstalledVersion( false )
+    , visibleInfo( I_Technical )
 {
     yuiDebug() << "NCPkgTable created" << endl;
 }
@@ -164,9 +163,8 @@ void NCPkgTable::addLine( ZyppStatus stat,
     tabItem->addCell( new NCPkgTableTag( objPtr, slbPtr, stat ));
 
 
-    for(const std::string& s: elements) {
+    for ( const std::string& s: elements )
 	tabItem->addCell(s);
-    };
 
     // use all-at-once insertion mode - DrawPad() is called only after the loop
     addItem(tabItem, true);
@@ -239,8 +237,9 @@ bool NCPkgTable::changeStatus( ZyppStatus newstatus,
 		header = NCPkgStrings::WarningLabel();
 	    }
 	break;
-        //display notify msg only if we mark pkg for installation
-        //disregard update, to be consistent with Qt (#308410)
+
+        // display notify msg only if we mark pkg for installation
+        // disregard update, to be consistent with Qt (#308410)
 	case S_Install:
 	    if ( objPtr )
 	    {
@@ -248,6 +247,7 @@ bool NCPkgTable::changeStatus( ZyppStatus newstatus,
 		yuiMilestone() << "NOTIFY message: " << notify << endl;
 		header = NCPkgStrings::NotifyLabel();
 	    }
+            // FALLTHROUGH
 	case S_Update:
 	case S_AutoInstall:
 	case S_AutoUpdate:
@@ -291,7 +291,9 @@ bool NCPkgTable::changeStatus( ZyppStatus newstatus,
 	    }
 
 	    ok = false;
-	} else {
+	}
+        else
+        {
 	    yuiMilestone() << "User confirmed license agreement for " << pkgName << endl;
 	    slbPtr->setLicenceConfirmed (true);
 	}
@@ -305,7 +307,7 @@ bool NCPkgTable::changeStatus( ZyppStatus newstatus,
 					      "<i>" + pkgName + "</i><br><br>" + html_text
 					      );
 	info->setPreferredSize( (NCurses::cols() * 50)/100, (NCurses::lines() * 30)/100);
-	info->showInfoPopup( );
+	info->showInfoPopup();
 
 	YDialog::deleteTopmostDialog();
     }
@@ -436,7 +438,7 @@ bool NCPkgTable::updateTable()
 //
 static bool slbHasInstalledObj (const ZyppSel & slb)
 {
-    return ! slb->installedEmpty ();
+    return ! slb->installedEmpty();
 }
 
 ///////////////////////////////////////////////////////////////////
@@ -445,16 +447,17 @@ static bool slbHasInstalledObj (const ZyppSel & slb)
 //
 // Fillup the column headers of the package table
 //
-void NCPkgTable::fillHeader( )
+void NCPkgTable::fillHeader()
 {
     std::vector<std::string> header;
 
     switch ( tableType )
     {
 	case T_Packages:
-	case T_Update: {
-	    bool haveInstalledPkgs = find_if (zyppPkgBegin (), zyppPkgEnd (),
-					      slbHasInstalledObj) != zyppPkgEnd ();
+	case T_Update:
+        {
+	    bool haveInstalledPkgs = find_if (zyppPkgBegin(), zyppPkgEnd(),
+					      slbHasInstalledObj) != zyppPkgEnd();
 
 	    header.reserve(7);
 	    header.push_back( "L" + NCPkgStrings::PkgStatus() );
@@ -477,7 +480,8 @@ void NCPkgTable::fillHeader( )
 #endif
 	    break;
 	}
-	case T_PatchPkgs: {
+	case T_PatchPkgs:
+        {
 	    header.reserve(7);
 	    header.push_back( "L" + NCPkgStrings::PkgStatus() );
 	    header.push_back( "L" + NCPkgStrings::PkgName() );
@@ -487,7 +491,8 @@ void NCPkgTable::fillHeader( )
 	    header.push_back( "L" + NCPkgStrings::PkgSize() );
 	    break;
 	}
-	case T_Patches: {
+	case T_Patches:
+        {
 	    header.reserve(6);
 	    header.push_back( "L" + NCPkgStrings::PkgStatus() );
 	    header.push_back( "L" + NCPkgStrings::PkgName() );
@@ -497,20 +502,23 @@ void NCPkgTable::fillHeader( )
 	    // header.push_back( "L" + NCPkgStrings::PkgSize() );
 	    break;
 	}
-	case T_Selections: {
+	case T_Selections:
+        {
 	    header.reserve(3);
 	    header.push_back( "L" + NCPkgStrings::PkgStatus() );
 	    header.push_back( "L" + NCPkgStrings::PatternsLabel() );
 	    break;
 	}
-	case T_Languages: {
+	case T_Languages:
+        {
 	    header.reserve(4);
 	    header.push_back( "L" + NCPkgStrings::PkgStatus() );
 	    header.push_back( "L" + NCPkgStrings::LangCode() );
 	    header.push_back( "L" + NCPkgStrings::LangName() );
 	    break;
 	}
-	case T_Availables: {
+	case T_Availables:
+        {
 	    header.reserve(6);
 	    header.push_back( "L" + NCPkgStrings::PkgStatus() );
 	    header.push_back( "L" + NCPkgStrings::PkgName() );
@@ -521,7 +529,8 @@ void NCPkgTable::fillHeader( )
 	    header.push_back( "L" + NCPkgStrings::PkgArch() );
 	    break;
 	}
-        case T_MultiVersion: {
+        case T_MultiVersion:
+        {
 	    header.reserve(5);
 	    header.push_back( "L" + NCPkgStrings::PkgStatus() );
 	    header.push_back( "L" + NCPkgStrings::PkgName() );
@@ -597,7 +606,8 @@ bool NCPkgTable::createListEntry ( ZyppPkg pkgPtr, ZyppSel slbPtr )
 
 	    break;
 	}
-	case T_Availables: {
+	case T_Availables:
+        {
             std::string isCandidate = "   ";
             if ( pkgPtr == slbPtr->candidateObj() )
                 isCandidate = " x ";
@@ -629,7 +639,8 @@ bool NCPkgTable::createListEntry ( ZyppPkg pkgPtr, ZyppSel slbPtr )
 
 	    break;
 	}
-        case T_MultiVersion: {
+        case T_MultiVersion:
+        {
             version = pkgPtr->edition().asString();
             pkgLine.push_back( version );
             // show the name of the repository (the installation source)
@@ -759,7 +770,7 @@ bool NCPkgTable::createPatchEntry ( ZyppPatch patchPtr, ZyppSel	slb )
 // showInformation
 //
 //
-bool NCPkgTable::showInformation ( )
+bool NCPkgTable::showInformation()
 {
     ZyppObj objPtr = getDataPointer( getCurrentItem() );
     ZyppSel slbPtr = getSelPointer( getCurrentItem() );
@@ -818,34 +829,33 @@ NCursesEvent NCPkgTable::wHandleInput( wint_t key )
 	case KEY_NPAGE:
 	case KEY_PPAGE:
 	case KEY_END:
-	case KEY_HOME: {
+	case KEY_HOME:
 	    // show the corresponding information
-	    showInformation( );
+	    showInformation();
 	    break;
-	}
+
 	case KEY_SPACE:
-	case KEY_RETURN: {
+	case KEY_RETURN:
 	    // toggle status
-	    toggleObjStatus( );
+	    toggleObjStatus();
 	    break;
-	}
-	//from the parent class, to enable sorting
-	case CTRL('o'): {
+
+            // from the parent class, to enable sorting
+	case CTRL('o'):
 	    NCTable::wHandleInput( key);
 	    break;
-	}
+
         case '-':
         case '+':
         case '>':
         case '<':
         case '!':
-        case '*': {
+        case '*':
 	    // set the new status
 	    changeObjStatus( key );
-	}
-	default: {
+
+	default:
 	    break;
-	}
     }
 
     NCDialog * currentDialog = static_cast<NCDialog *>(YDialog::topmostDialog());
@@ -876,7 +886,7 @@ ZyppObj NCPkgTable::getDataPointer( int index )
     // get the tag
     NCPkgTableTag *cc = getTag( index );
     if ( !cc )
-	return ZyppObj( );
+	return ZyppObj();
 
     return cc->getDataPointer();
 }
@@ -886,7 +896,7 @@ ZyppSel NCPkgTable::getSelPointer( int index )
     // get the tag
     NCPkgTableTag *cc = getTag( index );
     if ( !cc )
-	return ZyppSel( );
+	return ZyppSel();
 
     return cc->getSelPointer();
 }
@@ -958,7 +968,7 @@ bool NCPkgTable::SourceInstall( bool install )
 // NCPkgTable::toggleObjStatus()
 //
 //
-bool NCPkgTable::toggleObjStatus( )
+bool NCPkgTable::toggleObjStatus()
 {
     ZyppSel slbPtr = getSelPointer( getCurrentItem() );
     ZyppObj objPtr = getDataPointer( getCurrentItem() );
@@ -1023,18 +1033,22 @@ bool NCPkgTable::changeListObjStatus( NCPkgTableListAction type )
 
 	if ( slbPtr )
 	{
-	    switch ( type ) {
-		case A_Install: {
+	    switch ( type )
+            {
+		case A_Install:
+                {
 		    if ( slbPtr->status() == S_NoInst )
 			ok = statusStrategy->keyToStatus( '+', slbPtr, objPtr, newStatus );
 		    break;
 		}
-		case A_Delete: {
+		case A_Delete:
+                {
 		    if ( slbPtr->installedObj() && slbPtr->status() != S_Protected )
 			ok = statusStrategy->keyToStatus( '-', slbPtr, objPtr, newStatus );
 		    break;
 		}
-		case A_UpdateNewer: {
+		case A_UpdateNewer:
+                {
                     // set status to update respecting "vendor change" settings
                     if ( slbPtr->installedObj() && slbPtr->status() != S_Protected && slbPtr->updateCandidateObj() )
                     {
@@ -1043,12 +1057,14 @@ bool NCPkgTable::changeListObjStatus( NCPkgTableListAction type )
                     }
 		    break;
 		}
-		case A_Update: {
+		case A_Update:
+                {
 		    if ( slbPtr->installedObj() && slbPtr->status() != S_Protected )
 			ok = statusStrategy->keyToStatus( '>', slbPtr, objPtr, newStatus );
 		    break;
 		}
-		case A_Keep: {
+		case A_Keep:
+                {
 		    if ( slbPtr->status() == S_Install
 			 ||  slbPtr->status() == S_AutoInstall
 		         ||  slbPtr->status() == S_Update
@@ -1061,6 +1077,7 @@ bool NCPkgTable::changeListObjStatus( NCPkgTableListAction type )
 		}
 		default:
 		    yuiError() << "Unknown list action" << endl;
+                    break;
 	    }
 
 	    if ( ok )
@@ -1078,7 +1095,6 @@ bool NCPkgTable::changeListObjStatus( NCPkgTableListAction type )
     // do the updates now
     packager->showPackageDependencies( false );
     packager->showDiskSpace();
-
     updateTable();
 
     return true;
@@ -1093,7 +1109,7 @@ bool NCPkgTable::fillAvailableList ( ZyppSel slb )
     }
 
     // clear the package table
-    itemsCleared ();
+    itemsCleared();
 
     NCPkgStatusStrategy * strategy;
     NCPkgTableType type;
@@ -1161,10 +1177,10 @@ bool NCPkgTable::fillAvailableList ( ZyppSel slb )
 bool NCPkgTable::fillSummaryList( NCPkgTable::NCPkgTableListType type )
 {
     // clear the package table
-    itemsCleared ();
+    itemsCleared();
 
     // get the package list and sort it
-    std::list<ZyppSel> pkgList( zyppPkgBegin (), zyppPkgEnd () );
+    std::list<ZyppSel> pkgList( zyppPkgBegin(), zyppPkgEnd() );
     pkgList.sort( sortByName );
 
     // fill the package table
@@ -1175,7 +1191,7 @@ bool NCPkgTable::fillSummaryList( NCPkgTable::NCPkgTableListType type )
     // the installation summary.
     // This is not necessary because the dependencies will be solved and the
     // "Automatic Changes" list will be shown if the OK button is pressed.
-    //if ( !autoCheck )
+    // if ( !autoCheck )
     //{
 	// showPackageDependencies( true );
     //}
@@ -1183,25 +1199,25 @@ bool NCPkgTable::fillSummaryList( NCPkgTable::NCPkgTableListType type )
     for ( listIt = pkgList.begin(); listIt != pkgList.end();  ++listIt )
     {
 	ZyppSel selectable = *listIt;
-	ZyppPkg pkg = tryCastToZyppPkg (selectable->theObj ());
+	ZyppPkg pkg = tryCastToZyppPkg (selectable->theObj());
 	// show all matching packages
 	switch ( type )
 	{
-	    case NCPkgTable::L_Changes: {
+	    case NCPkgTable::L_Changes:
 		if ( selectable->status() != S_NoInst
 		     && selectable->status() != S_KeepInstalled )
 		{
 		    createListEntry( pkg, selectable );
 		}
 		break;
-	    }
-	    case NCPkgTable::L_Installed: {
+
+	    case NCPkgTable::L_Installed:
 		if ( selectable->status() == S_KeepInstalled )
 		{
 		    createListEntry( pkg, selectable );
 		}
 		break;
-	    }
+
 	    default:
 		break;
 	}
@@ -1215,38 +1231,43 @@ bool NCPkgTable::fillSummaryList( NCPkgTable::NCPkgTableListType type )
 
 void NCPkgTable::updateInfo( ZyppObj pkgPtr, ZyppSel slbPtr, NCPkgTableInfoType mode )
 {
-    switch (mode)
+    switch ( mode )
     {
 	case I_Descr:
 	    if ( packager->InfoText() )
 		packager->InfoText()->longDescription( pkgPtr );
 	    break;
+
 	case I_Technical:
 	    if ( packager->InfoText() )
 		packager->InfoText()->technicalData( pkgPtr, slbPtr );
 	    break;
+
 	case I_Files:
 	    if ( packager->InfoText() )
 		packager->InfoText()->fileList( slbPtr );
 	    break;
+
 	case I_Deps:
 	    if ( packager->InfoText() )
 		packager->InfoText()->dependencyList( pkgPtr, slbPtr );
 	    break;
+
 	case I_Versions:
 	    if ( packager->VersionsList() )
 		packager->VersionsList()->fillAvailableList( slbPtr );
 	    break;
+
 	case I_PatchDescr:
 	    if ( packager->InfoText() )
 		packager->InfoText()->patchDescription( pkgPtr, slbPtr );
 	    break;
+
 	case I_PatchPkgs:
 	    if ( packager->PatchPkgs() )
-            {
 		packager->fillPatchPackages( packager->PatchPkgs(), pkgPtr );
-            }
 	    break;
+
 	// Intentionally omitting 'default' branch so the compiler can
 	// catch unhandled enum states
     }

--- a/src/NCPkgTable.cc
+++ b/src/NCPkgTable.cc
@@ -582,7 +582,7 @@ bool NCPkgTable::createListEntry ( ZyppPkg pkgPtr, ZyppSel slbPtr )
     std::string version = "";
     ZyppStatus status;
 
-    switch( tableType )
+    switch ( tableType )
     {
 	case T_PatchPkgs: {
     	    // if the package is installed, get the installed version
@@ -622,6 +622,10 @@ bool NCPkgTable::createListEntry ( ZyppPkg pkgPtr, ZyppSel slbPtr )
             pkgLine.push_back( isCandidate );
 
             version = pkgPtr->edition().asString();
+
+            if ( pkgPtr->isRetracted() )
+                version += " " + NCPkgStrings::RetractedLabel();
+
             pkgLine.push_back( version );
             // show the name of the repository (the installation source)
             pkgLine.push_back( pkgPtr->repository().info().name() );
@@ -650,6 +654,10 @@ bool NCPkgTable::createListEntry ( ZyppPkg pkgPtr, ZyppSel slbPtr )
         case T_MultiVersion:
         {
             version = pkgPtr->edition().asString();
+
+            if ( pkgPtr->isRetracted() )
+                version += " " + NCPkgStrings::RetractedLabel();
+
             pkgLine.push_back( version );
             // show the name of the repository (the installation source)
             pkgLine.push_back( pkgPtr->repository().info().name() );
@@ -1190,10 +1198,11 @@ bool NCPkgTable::fillSummaryList( NCPkgTable::NCPkgTableListType type )
     // the installation summary.
     // This is not necessary because the dependencies will be solved and the
     // "Automatic Changes" list will be shown if the OK button is pressed.
-    // if ( !autoCheck )
-    //{
-	// showPackageDependencies( true );
-    //}
+    //
+    //   if ( !autoCheck )
+    //   {
+    //       showPackageDependencies( true );
+    //   }
 
     for ( listIt = pkgList.begin(); listIt != pkgList.end();  ++listIt )
     {

--- a/src/NCPkgTable.cc
+++ b/src/NCPkgTable.cc
@@ -1142,34 +1142,12 @@ bool NCPkgTable::fillAvailableList ( ZyppSel slb )
         ++it;
     }
 
-#if 0
-    // show installed packages
-    {
-        zypp::ui::Selectable::installed_iterator it = slb->installedBegin();
-        while ( it != slb->installedEnd() )
-        {
-            createListEntry( tryCastToZyppPkg(*it), slb );
-            ++it;
-        }
-    }
-    // and all availables
-    {
-        zypp::ui::Selectable::available_iterator it = slb->availableBegin();
-        while ( it != slb->availableEnd() )
-        {
-            createListEntry( tryCastToZyppPkg(*it), slb );
-            ++it;
-        }
-    }
-#endif
-
     // show the package list
     drawList();
 
     if ( getNumLines() > 0 )
-    {
 	setCurrentItem( 0 );
-    }
+
     return true;
 
 }

--- a/src/NCPkgTable.h
+++ b/src/NCPkgTable.h
@@ -67,14 +67,14 @@ class NCPackageSelector;
  **/
 class NCPkgTableTag : public YTableCell
 {
-  private:
+private:
 
     ZyppStatus status;
     ZyppObj dataPointer;
     // cannot get at it from dataPointer
     ZyppSel selPointer;
 
-  public:
+public:
 
     NCPkgTableTag( ZyppObj pkgPtr,
 		   ZyppSel selPtr,
@@ -83,12 +83,12 @@ class NCPkgTableTag : public YTableCell
     ~NCPkgTableTag() {}
 
     void setStatus( ZyppStatus  stat ) { status = stat; }
-    ZyppStatus getStatus() const   { return status; }
+    ZyppStatus getStatus() const { return status; }
     // returns the corresponding std::string value to given package status
     std::string statusToString( ZyppStatus stat ) const;
 
-    ZyppObj getDataPointer() const		{ return dataPointer; }
-    ZyppSel getSelPointer() const		{ return selPointer; }
+    ZyppObj getDataPointer() const { return dataPointer; }
+    ZyppSel getSelPointer() const  { return selPointer; }
 };
 
 
@@ -98,32 +98,31 @@ public:
 
     NCPkgTableSort( const std::vector<std::string> & head )
 	: _header ( head )
-	{ }
+	{}
 
-    virtual void sort (
-		       std::vector<NCTableLine *>::iterator itemsBegin,
-		       std::vector<NCTableLine *>::iterator itemsEnd
-		       ) override
+    virtual void sort ( std::vector<NCTableLine *>::iterator itemsBegin,
+                        std::vector<NCTableLine *>::iterator itemsEnd ) override
+    {
+        if ( _header[ getColumn() ] == NCPkgStrings::PkgSize() )
         {
-	    if ( _header[ getColumn() ] == NCPkgStrings::PkgSize() )
-	    {
-		std::sort( itemsBegin, itemsEnd, CompareSize() );
-	    }
-	    else if ( _header[ getColumn() ] == NCPkgStrings::PkgName() )
-	    {
-		std::sort( itemsBegin, itemsEnd, CompareName( getColumn() ) );
-	    }
-	    else
-	    {
-		std::sort( itemsBegin, itemsEnd, Compare( getColumn() ) );
-	    }
+            std::sort( itemsBegin, itemsEnd, CompareSize() );
+        }
+        else if ( _header[ getColumn() ] == NCPkgStrings::PkgName() )
+        {
+            std::sort( itemsBegin, itemsEnd, CompareName( getColumn() ) );
+        }
+        else
+        {
+            std::sort( itemsBegin, itemsEnd, Compare( getColumn() ) );
+        }
 
-	    if ( isReverse() )
-		std::reverse( itemsBegin, itemsEnd );
-	}
+        if ( isReverse() )
+            std::reverse( itemsBegin, itemsEnd );
+    }
 
 private:
     std::vector<std::string> _header;
+
 
     class CompareSize
     {
@@ -132,18 +131,18 @@ private:
 	    {}
 
 	bool operator() ( const NCTableLine * first,
-			  const NCTableLine * second
-			  ) const
-	    {
-		const YTableItem *firstItem = dynamic_cast<const YTableItem*> (first->origItem() );
-		const YTableItem *secondItem = dynamic_cast<const YTableItem*> (second->origItem() );
-		const NCPkgTableTag *firstTag = static_cast<const NCPkgTableTag *>( firstItem->cell(0) );
-		const NCPkgTableTag *secondTag = static_cast<const NCPkgTableTag *>( secondItem->cell(0) );
+			  const NCTableLine * second ) const
+	{
+            const YTableItem *firstItem = dynamic_cast<const YTableItem*> (first->origItem() );
+            const YTableItem *secondItem = dynamic_cast<const YTableItem*> (second->origItem() );
+            const NCPkgTableTag *firstTag = static_cast<const NCPkgTableTag *>( firstItem->cell(0) );
+            const NCPkgTableTag *secondTag = static_cast<const NCPkgTableTag *>( secondItem->cell(0) );
 
-		return firstTag->getDataPointer()->installSize() <
-		       secondTag->getDataPointer()->installSize();
-	    }
+            return firstTag->getDataPointer()->installSize() <
+                secondTag->getDataPointer()->installSize();
+        }
     };
+
 
     class CompareName
     {
@@ -153,25 +152,25 @@ private:
 	    {}
 
 	bool operator() ( const NCTableLine * first,
-			  const NCTableLine * second
-			  ) const
-	    {
-                std::wstring w1 = first->GetCol( _uiCol )->Label().getText().begin()->str();
-                std::wstring w2 = second->GetCol( _uiCol )->Label().getText().begin()->str();
+			  const NCTableLine * second ) const
+	{
+            std::wstring w1 = first->GetCol( _uiCol )->Label().getText().begin()->str();
+            std::wstring w2 = second->GetCol( _uiCol )->Label().getText().begin()->str();
 
-                // It is safe to use collate unaware wscasecmp() here because package names
-                // are 7 bit ASCII only. Better yet, we don't even want this to be sorted
-                // by locale specific rules: "ch" for example would be sorted after "h" in
-                // Czech which in the context of package names (which are English) would be
-                // plain wrong.
-                int result = wcscasecmp( w1.data(), w2.data() );
+            // It is safe to use collate unaware wscasecmp() here because package names
+            // are 7 bit ASCII only. Better yet, we don't even want this to be sorted
+            // by locale specific rules: "ch" for example would be sorted after "h" in
+            // Czech which in the context of package names (which are English) would be
+            // plain wrong.
+            int result = wcscasecmp( w1.data(), w2.data() );
 
-		return result < 0;
-	    }
+            return result < 0;
+        }
 
     private:
 	const int _uiCol;
     };
+
 
     class Compare
     {
@@ -181,16 +180,16 @@ private:
 	    {}
 
 	bool operator() ( const NCTableLine * first,
-			  const NCTableLine * second
-			  ) const
-	    {
-                std::wstring w1 = first->GetCol( _uiCol )->Label().getText().begin()->str();
-                std::wstring w2 = second->GetCol( _uiCol )->Label().getText().begin()->str();
+			  const NCTableLine * second ) const
+	{
+            std::wstring w1 = first->GetCol( _uiCol )->Label().getText().begin()->str();
+            std::wstring w2 = second->GetCol( _uiCol )->Label().getText().begin()->str();
 
-		int result = wcscoll ( w1.data(), w2.data() );
+            int result = wcscoll ( w1.data(), w2.data() );
 
-		return result < 0;
-	    }
+            return result < 0;
+        }
+
     private:
 	const int _uiCol;
     };
@@ -206,7 +205,7 @@ private:
 class NCPkgTable : public NCTable
 {
 public:
-    
+
     enum NCPkgTableType
     {
 	T_Packages,
@@ -267,57 +266,55 @@ private:
 
     std::vector<std::string> header;		// the table header
 
-protected:
-
 
 public:
 
-   /**
-    * Constructor
-    */
+    /**
+     * Constructor
+     */
     NCPkgTable( YWidget * parent, YTableHeader * tableHeader );
 
     virtual ~NCPkgTable();
 
 
-   /**
-    * This method is called to add a line to the package list.
-    * @param status The package status (first column of the table)
-    * @param elements A std::vector<std::string> containing the package data
-    * @param objPtr The pointer to the packagemanager object
-    * @param objPtr The pointer to the selectable object
-    * @return void
-    */
+    /**
+     * This method is called to add a line to the package list.
+     * @param status The package status (first column of the table)
+     * @param elements A std::vector<std::string> containing the package data
+     * @param objPtr The pointer to the packagemanager object
+     * @param objPtr The pointer to the selectable object
+     * @return void
+     */
     virtual void addLine( ZyppStatus status,
 			  const std::vector<std::string> & elements,
 			  ZyppObj objPtr,
 			  ZyppSel slbPtr );
 
-   /**
+    /**
      * Draws the package list (has to be called after the loop with addLine() calls)
      */
-   void drawList() { myPad()->setOrder(1); return DrawPad(); }
+    void drawList() { myPad()->setOrder(1); return DrawPad(); }
 
-   /**
-    * Clears the package list
-    */
+    /**
+     * Clears the package list
+     */
     virtual void itemsCleared();
 
-   /**
-    * Changes the contents of a certain cell in table
-    * @param index The table line
-    * @param column The column
-    * @param newtext The new text
-    * @eturn void
-    */
+    /**
+     * Changes the contents of a certain cell in table
+     * @param index The table line
+     * @param column The column
+     * @param newtext The new text
+     * @eturn void
+     */
     virtual void cellChanged( int index, int colnum, const std::string & newtext );
 
-   /**
-    * Returns the contents of a certain cell in table
-    * @param index The table line
-    * @param column The column
-    * @eturn NClabel
-    */
+    /**
+     * Returns the contents of a certain cell in table
+     * @param index The table line
+     * @param column The column
+     * @eturn NClabel
+     */
     NClabel getCellContents( int index, int colnum );
 
     /**
@@ -328,7 +325,7 @@ public:
      */
     virtual NCursesEvent wHandleInput( wint_t key );
 
-   /**
+    /**
      * Sets the member variable PackageSelector *packager
      * @param pkg The PackageSelector pointer
      * @return void
@@ -355,7 +352,7 @@ public:
 
     bool toggleObjStatus();
 
-   /**
+    /**
      * Set the status information if status has changed
      * @return bool
      */
@@ -385,7 +382,8 @@ public:
      * 			Has to be allocated with new - is deleted by NCPkgTable.
      * @return bool
      */
-    bool setTableType( NCPkgTableType type, NCPkgStatusStrategy * strategy ) {
+    bool setTableType( NCPkgTableType type, NCPkgStatusStrategy * strategy )
+    {
 	if ( !strategy )
 	    return false;
 
@@ -412,7 +410,7 @@ public:
      */
     ZyppSel getSelPointer( int index );
 
-   /**
+    /**
      * Returns the number of lines in the table (the table size)
      * @return unsigned int
      */
@@ -430,36 +428,36 @@ public:
      * @param slbPtr The selectable pointer
      * @return bool
      */
-   bool createListEntry ( ZyppPkg pkgPtr, ZyppSel slbPtr );
+    bool createListEntry ( ZyppPkg pkgPtr, ZyppSel slbPtr );
 
-   /**
+    /**
      * Creates a line in the YOU patch table.
      * @param pkgPtr The YOU patch pointer
      * @return bool
      */
-   bool createPatchEntry ( ZyppPatch pkgPtr,  ZyppSel slbPtr );
+    bool createPatchEntry ( ZyppPatch pkgPtr,  ZyppSel slbPtr );
 
-   /**
-    * Creates a line in the table shwing an info text.
-    * @param text The information
-    * @return bool
-    */
-   bool createInfoEntry ( std::string text );
+    /**
+     * Creates a line in the table shwing an info text.
+     * @param text The information
+     * @return bool
+     */
+    bool createInfoEntry ( std::string text );
 
-   /**
-    * Show the corresponding information (e.g. the package description).
-    * @return bool
-    */
-   bool showInformation();
+    /**
+     * Show the corresponding information (e.g. the package description).
+     * @return bool
+     */
+    bool showInformation();
 
-   void setVisibleInfo( NCPkgTableInfoType info) { visibleInfo = info;  }
+    void setVisibleInfo( NCPkgTableInfoType info) { visibleInfo = info;  }
 
-   NCPkgTableInfoType VisibleInfo() { return visibleInfo; }
+    NCPkgTableInfoType VisibleInfo() { return visibleInfo; }
 
-   bool fillAvailableList ( ZyppSel slb );
-   bool fillSummaryList ( NCPkgTableListType type );
+    bool fillAvailableList ( ZyppSel slb );
+    bool fillSummaryList ( NCPkgTableListType type );
 
-   void updateInfo( ZyppObj pkgPtr, ZyppSel slbPtr, NCPkgTableInfoType mode );
+    void updateInfo( ZyppObj pkgPtr, ZyppSel slbPtr, NCPkgTableInfoType mode );
 
 };
 

--- a/src/NCPkgTable.h
+++ b/src/NCPkgTable.h
@@ -65,8 +65,8 @@ class NCPackageSelector;
  * not installed, to be deleted and so on).
  *
  **/
-class NCPkgTableTag : public YTableCell {
-
+class NCPkgTableTag : public YTableCell
+{
   private:
 
     ZyppStatus status;
@@ -92,8 +92,8 @@ class NCPkgTableTag : public YTableCell {
 };
 
 
-class NCPkgTableSort : public NCTableSortStrategyBase {
-
+class NCPkgTableSort : public NCTableSortStrategyBase
+{
 public:
 
     NCPkgTableSort( const std::vector<std::string> & head )
@@ -128,7 +128,7 @@ private:
     class CompareSize
     {
     public:
-	CompareSize ( )
+	CompareSize()
 	    {}
 
 	bool operator() ( const NCTableLine * first,
@@ -203,10 +203,12 @@ private:
  * changes which affect other widgets.
  *
  **/
-class NCPkgTable : public NCTable {
-
+class NCPkgTable : public NCTable
+{
 public:
-    enum NCPkgTableType {
+    
+    enum NCPkgTableType
+    {
 	T_Packages,
 	T_Availables,
 	T_Patches,
@@ -218,7 +220,8 @@ public:
 	T_Unknown
     };
 
-    enum NCPkgTableListAction {
+    enum NCPkgTableListAction
+    {
 	A_Install,
 	A_Delete,
 	A_Keep,
@@ -227,13 +230,15 @@ public:
 	A_Unknown
     };
 
-    enum NCPkgTableListType {
+    enum NCPkgTableListType
+    {
 	L_Changes,
 	L_Installed,
 	L_Unknown
     };
 
-    enum NCPkgTableInfoType {
+    enum NCPkgTableInfoType
+    {
 	I_Descr,
 	I_Technical,
 	I_Versions,
@@ -291,7 +296,7 @@ public:
    /**
      * Draws the package list (has to be called after the loop with addLine() calls)
      */
-   void drawList( ) { myPad()->setOrder(1); return DrawPad(); }
+   void drawList() { myPad()->setOrder(1); return DrawPad(); }
 
    /**
     * Clears the package list
@@ -348,7 +353,7 @@ public:
 
     bool changeListObjStatus( NCPkgTableListAction key );
 
-    bool toggleObjStatus( );
+    bool toggleObjStatus();
 
    /**
      * Set the status information if status has changed
@@ -411,13 +416,13 @@ public:
      * Returns the number of lines in the table (the table size)
      * @return unsigned int
      */
-    unsigned int getNumLines( ) { return myPad()->Lines(); }
+    unsigned int getNumLines() { return myPad()->Lines(); }
 
     /**
      * Fills the header of the table
      * @return void
      */
-    void fillHeader( );
+    void fillHeader();
 
     /**
      * Creates a line in the package table.
@@ -445,11 +450,11 @@ public:
     * Show the corresponding information (e.g. the package description).
     * @return bool
     */
-   bool showInformation ( );
+   bool showInformation();
 
    void setVisibleInfo( NCPkgTableInfoType info) { visibleInfo = info;  }
 
-   NCPkgTableInfoType VisibleInfo() { return visibleInfo ; }
+   NCPkgTableInfoType VisibleInfo() { return visibleInfo; }
 
    bool fillAvailableList ( ZyppSel slb );
    bool fillSummaryList ( NCPkgTableListType type );

--- a/src/NCZypp.h
+++ b/src/NCZypp.h
@@ -49,7 +49,6 @@
 #include <zypp/Package.h>
 #include <zypp/Pattern.h>
 #include <zypp/Product.h>
-//#include <zypp/Language.h>
 #include <zypp/Patch.h>
 #include <zypp/ZYppFactory.h>
 #include <zypp/ResPoolProxy.h>
@@ -77,7 +76,6 @@ typedef zypp::ui::Selectable::Ptr		ZyppSel;
 typedef zypp::ResObject::constPtr		ZyppObj;
 typedef zypp::Package::constPtr			ZyppPkg;
 typedef zypp::Pattern::constPtr			ZyppPattern;
-// typedef zypp::Language::constPtr		ZyppLang;
 typedef zypp::Patch::constPtr			ZyppPatch;
 typedef zypp::Product::constPtr			ZyppProduct;
 typedef zypp::Repository			ZyppRepo;
@@ -97,9 +95,6 @@ inline ZyppPoolIterator zyppPkgEnd()		{ return zyppEnd<zypp::Package>();	}
 
 inline ZyppPoolIterator zyppPatternsBegin()	{ return zyppBegin<zypp::Pattern>();	}
 inline ZyppPoolIterator zyppPatternsEnd()	{ return zyppEnd<zypp::Pattern>();	}
-
-// inline ZyppPoolIterator zyppLangBegin()		{ return zyppBegin<zypp::Language>();	}
-// inline ZyppPoolIterator zyppLangEnd()		{ return zyppEnd<zypp::Language>();	}
 
 inline ZyppPoolIterator zyppPatchesBegin()	{ return zyppBegin<zypp::Patch>();	}
 inline ZyppPoolIterator zyppPatchesEnd()	{ return zyppEnd<zypp::Patch>();	}
@@ -121,12 +116,6 @@ inline ZyppPattern 	tryCastToZyppPattern( ZyppObj zyppObj )
     return zypp::dynamic_pointer_cast<const zypp::Pattern>( zyppObj );
 }
 
-#if 0
-inline ZyppLang		tryCastToZyppLang( ZyppObj zyppObj )
-{
-    return zypp::dynamic_pointer_cast<const zypp::Language>( zyppObj );
-}
-#endif
 inline ZyppPatch	tryCastToZyppPatch( ZyppObj zyppObj )
 {
     return zypp::dynamic_pointer_cast<const zypp::Patch>( zyppObj );
@@ -141,7 +130,6 @@ template<typename T> bool inContainer( const std::set<T> & container, T search )
 {
     return container.find( search ) != container.end();
 }
-
 
 template<typename T> bool bsearch( const std::vector<T> & sorted_vector, T search )
 {

--- a/src/NCZypp.h
+++ b/src/NCZypp.h
@@ -77,7 +77,7 @@ typedef zypp::ui::Selectable::Ptr		ZyppSel;
 typedef zypp::ResObject::constPtr		ZyppObj;
 typedef zypp::Package::constPtr			ZyppPkg;
 typedef zypp::Pattern::constPtr			ZyppPattern;
-//typedef zypp::Language::constPtr		ZyppLang;
+// typedef zypp::Language::constPtr		ZyppLang;
 typedef zypp::Patch::constPtr			ZyppPatch;
 typedef zypp::Product::constPtr			ZyppProduct;
 typedef zypp::Repository			ZyppRepo;
@@ -98,8 +98,8 @@ inline ZyppPoolIterator zyppPkgEnd()		{ return zyppEnd<zypp::Package>();	}
 inline ZyppPoolIterator zyppPatternsBegin()	{ return zyppBegin<zypp::Pattern>();	}
 inline ZyppPoolIterator zyppPatternsEnd()	{ return zyppEnd<zypp::Pattern>();	}
 
-//inline ZyppPoolIterator zyppLangBegin()		{ return zyppBegin<zypp::Language>();	}
-//inline ZyppPoolIterator zyppLangEnd()		{ return zyppEnd<zypp::Language>();	}
+// inline ZyppPoolIterator zyppLangBegin()		{ return zyppBegin<zypp::Language>();	}
+// inline ZyppPoolIterator zyppLangEnd()		{ return zyppEnd<zypp::Language>();	}
 
 inline ZyppPoolIterator zyppPatchesBegin()	{ return zyppBegin<zypp::Patch>();	}
 inline ZyppPoolIterator zyppPatchesEnd()	{ return zyppEnd<zypp::Patch>();	}


### PR DESCRIPTION
## Trello

https://trello.com/c/lRisXHUt/1556-8-package-selector-improvements-for-sle-8770-new-status-retracted

## Jira

https://jira.suse.com/browse/SLE-11211

Related:
https://jira.suse.com/browse/SLE-8770

## Summary

Add the new _retracted_ status to the package selector in the YaST NCurses UI.

## Related PR

https://github.com/libyui/libyui-qt-pkg/pull/82 (Qt part)

## Package Versions View

Now retracted versions of the current package are displayed with a text [RETRACTED] :

![nc-retracted-versions](https://user-images.githubusercontent.com/11538225/72532964-96778b00-3874-11ea-9f69-ed94e0cc8e74.png)

(Simulated test data since the test repo has been broken for 24+ hours)

## New Classification Filter: Retracted Packages

Added two new filters:

- Retracted Packages
- Retracted Installed Packages

![nc-retracted-pkg-class](https://user-images.githubusercontent.com/11538225/72532978-9d060280-3874-11ea-9dd5-a821747f6fd4.png)

(Both empty since the test repo has been broken for 24+ hours)

## Switch to Retracted Installed Packages View if any Installed

Same as in the Qt UI:

When entering the package selector in normal mode (i.e. not showing patterns, patches, upgrade problems etc.), check if any retracted package versions are installed. If there are any, switch to the "Package Classification" filter view and activate the "Retracted Installed Packages" filter.

## Preventing Auto-Selecting Retracted Package Versions

Same as in the Qt UI:

Libzypp already takes care about that. Libzypp will not voluntarily take a retracted package version into consideration as a candidate. And if dependencies would make that necessary, this would become a (pretty complex) dependency problem that needs more sophisticated handling, very much like other dependency problems.

## Notes for Viewing the Diff

_**The diff is best viewed with whitespace changes suppressed.**_

Our mandatory C++ coding style was applied including indentation and fixing trailing whitespace, so there are many whitespace-only changes.