### PR TITLE
Use new libyui SO version 12

### DIFF
--- a/VERSION.cmake
+++ b/VERSION.cmake
@@ -1,9 +1,9 @@
 SET( VERSION_MAJOR "2" )
 SET( VERSION_MINOR "50" )
-SET( VERSION_PATCH "7" )
+SET( VERSION_PATCH "8" )
 SET( VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}" )
 
-##### This is need for the libyui core, ONLY.
+##### This is need for the libyui core ONLY.
 ##### These will be overridden from exports in LibyuiConfig.cmake
 SET( SONAME_MAJOR "0" )
 SET( SONAME_MINOR "0" )

--- a/package/libyui-ncurses-pkg-doc.spec
+++ b/package/libyui-ncurses-pkg-doc.spec
@@ -16,10 +16,10 @@
 #
 
 %define parent libyui-ncurses-pkg
-%define so_version 11
+%define so_version 12
 
 Name:           %{parent}-doc
-Version:        2.50.7
+Version:        2.50.8
 Release:        0
 Source:         %{parent}-%{version}.tar.bz2
 

--- a/package/libyui-ncurses-pkg.changes
+++ b/package/libyui-ncurses-pkg.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jun  4 13:08:07 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Use new parent lib SO version libyui.so.12 (bsc#1172513)
+- 2.50.8
+
+-------------------------------------------------------------------
 Tue May 19 15:40:06 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Allow vendor change also for distribution upgrade (bsc#1170521)

--- a/package/libyui-ncurses-pkg.spec
+++ b/package/libyui-ncurses-pkg.spec
@@ -17,11 +17,11 @@
 
 
 Name:           libyui-ncurses-pkg
-Version:        2.50.7
+Version:        2.50.8
 Release:        0
 Source:         %{name}-%{version}.tar.bz2
 
-%define so_version 11
+%define so_version 12
 %define bin_name %{name}%{so_version}
 
 %if 0%{?suse_version} > 1325


### PR DESCRIPTION
This is related to https://github.com/libyui/libyui/pull/165 :

The latest libyui needed to bump the SO version to 12 to maintain binary compatibility. The dependent packages like this need to adapt to that new version.
